### PR TITLE
code refactoring changes with macro attributes added to mapped existing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+### Changelog
+All related changes will be logged here.
+
+
+## [0.3.0] 2024-11-16
+- Adding macro attributes features on struct, existing mapped fields and new fields
+
+### Changed
+
+- **BREAKING:** Remove `unstringify` library crate dependency. it is no longer required for this version. You can uninstall it
+by issuing this command from your project. And remove any reference of it from your code base.
+```shell
+cargo remove unstringify
+```
+
+## [0.2.0] 2024-04-25
+- New computed field features added in order to create new fields from a base struct
+- **BREAKING:** Adding required dependency for `unstringify` library crate. It requires adding this crate to your project
+and import it where you need to use dto_mapper macro.
+
+## [0.1.3] 2023-12-22
+- New computed field features added in order to create new fields from a base struct
+- **BREAKING:** Adding required dependency for `derive_builder` library crate. It requires adding this crate to your project
+and import it where you need to use dto_mapper macro.
+
+## [0.1.2] 2023-11-20
+Initial version and publishing of dto_mapper crate.
+- Adding special macro mapper for dto mapping from a base struct. You can derive a struct from an existing one in order
+to use it for data transfer object design patterns. It has features that no existing rust dto lib crates has exposed in
+order to use dto design patterns in a flexible manner like "mapstruct" from Java world.
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "dto_mapper"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "derive_builder",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,18 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd33f37ee6a119146a1781d3356a7c26028f83d779b2e04ecd45fdc75c76877b"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7431fa049613920234f22c47fdc33e6cf3ee83067091ea4277a3f8c4587aae38"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abae7035bf79b9877b779505d8cf3749285b80c43941eda66604841889451dc"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
@@ -107,9 +107,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -131,18 +131,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -169,9 +169,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,8 @@ dependencies = [
  "derive_builder",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn",
  "unstringify",
 ]
@@ -92,6 +94,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +121,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "serde"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.210"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,6 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
- "unstringify",
 ]
 
 [[package]]
@@ -183,9 +182,3 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unstringify"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9612d66420ead229348915b911ad9689e79dfc347fe7a876a82551c8eab36b5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ derive_builder = "0.20"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = {version = "2.0", features = ["full"]}
-unstringify = "0.1"
 
 [dev-dependencies]
 derive_builder = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ version = "0.2.0"
 proc-macro = true
 
 [dependencies]
-derive_builder = "0.20.0"
-proc-macro2 = "1.0.81"
-quote = "1.0.36"
-syn = {version = "2", features = ["full"]}
-unstringify = "0.1.4"
+derive_builder = "0.20"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = {version = "2.0", features = ["full"]}
+unstringify = "0.1"
 
 [dev-dependencies]
-derive_builder = "0.20.0"
-serde = {version = "1", features = ["serde_derive", "derive"]}
+derive_builder = "0.20"
+serde = {version = "1.0", features = ["serde_derive", "derive"]}
 serde_json = {version = "1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["James Douglass Lefruit"]
 categories = ["data-structures", "web-programming", "rust-patterns"]
 description = "A library to create dynamic DTOs (Data Transfer Object) from a structure"
-documentation = "https://github.com/douggynix/dto_mapper/tree/0.2.0"
+documentation = "https://github.com/douggynix/dto_mapper/tree/0.3.0"
 edition = "2021"
 exclude = [
   ".github/workflows/rust.yml",
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 name = "dto_mapper"
 readme = "README.md"
 repository = "https://github.com/douggynix/dto_mapper"
-version = "0.2.0"
+version = "0.3.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 proc-macro = true

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ If we have to load a 'user' record from a database, we wouldn't want to send all
 This is where DTO Mapper Library comes handy.
 
 # Installation
-**_dto_mapper_** library depends on **_unstringify_** and **_derive_builder_** which implements builder pattern for dto objects resulted from the dto mappers.
+**_dto_mapper_** library depends **_derive_builder_** which implements builder pattern for dto objects resulted from the dto mappers.
 By default, it generate builder for the dtos.
+Early versions of the dto_mapper used to depend on **_unstringify_** crate. It is no longer required anymore and has been removed.
+If you are using this current version. You can remove this dependency from your project.
+
 You can use this instruction to install the latest version of **dto_mapper** library to your project
 ```shell
 cargo add derive_builder
 cargo add dto_mapper
-cargo add unstringify
 ```
 And import it to the rust source file you need to use it:
 ```rust
@@ -62,7 +64,7 @@ It takes only those lines below to get this work done. And the conversion are be
     #[allow(unused)]
     use std::str::FromStr;
     #[allow(unused)]
-    use unstringify::unstringify;
+
 
     fn concat_str(s1: &str, s2: &str) -> String {
         s1.to_owned() + " " + s2

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ use dto_mapper::DtoMapper;
 More details on how to use derive_builder crate here: https://crates.io/crates/derive_builder
 
 # Example
-Let's say we want to create 3 special entities for our application
+Let's say we want to create special struct derived from a base existing **struct User** for our application
 - LoginDto that will contain only 2 fields from **User** such as _**username**_ and _**password**_. we would like to rename _**username**_ to _**login**_ in LoginDto
 - ProfileDto that will contain all fields from **User** and  will ignore only the **password** field.
 - PersonDto that will contain only 3 fields from  **User** such as _**firstname**_, _**lastname**_, and _**email**_. But we would like to make the _**email**_ field optional such that its final data type will be  _**Option<T>**_. That is if email is **String** from User, it will result in _**Option<String>**_
-
+- CustomDtoWithAttribute that will create a new field called name which will be computed from two existing fields on the struct.
+  We will add as well serde macro attributes for serialization on the struct, on an existing and a new struct field as well
 It takes only those lines below to get this work done. And the conversion are being done automatically between one dto type to the original struct and vice versa.
 
   ```rust
@@ -64,7 +65,6 @@ It takes only those lines below to get this work done. And the conversion are be
     #[allow(unused)]
     use std::str::FromStr;
     #[allow(unused)]
-
 
     fn concat_str(s1: &str, s2: &str) -> String {
         s1.to_owned() + " " + s2
@@ -83,7 +83,7 @@ It takes only those lines below to get this work done. And the conversion are be
     #[mapper(
         dto="CustomDtoWithAttribute" ,
         no_builder=true ,
-        map=[ ("email",false) ],
+        map=[ ("email", false, ["#[serde(rename = \"email_address\")]"] ) ],
         derive=(Debug, Clone, Serialize, Deserialize),
         new_fields=[
             (

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ struct SourceStruct{ }
       if **ignore** is present , then **map** field becomes optional. Except if needed rename destination fields for the dto
     - **derive** : list of of macro to derive from. `derive=(Debug,Clone)`
     - **no_builder**: a boolean flag to turn on or off builders for the dto. Default value is **_false_**. If the Dto name is "MyDto" , the builder will create a struct named "MyDtoBuilder" that can be used to build "MyDto" struct.
-    - ***macro_attr**: an array of macro attributes to be added on the top of the resulted **struct**. For example : macro_attr=["serde(rename_all = \"UPPERCASE\")"]
+    - **macro_attr**: an array of macro attributes to be added on the top of the resulted **struct**. For example : macro_attr=["serde(rename_all = \"UPPERCASE\")"]
     - **new_fields** : an array of declaration of new field names to include to the resulted dto structure. `new_fields=[("fieldname:type"), ("initialize_expression") ), ["macro_attribute","macro_attribute"]`.
       `fieldname:type` will create a new field with the `fieldname` specified and the `type`. It is not mandatory to rename. you can have `map=[("fieldname",true)]`
       `initialize_expression` is used an initialize value or expression to use when converting the original structure to the dto.

--- a/examples/dto_example.rs
+++ b/examples/dto_example.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use unstringify::unstringify;
 
 fn concat_str(s1: &str, s2: &str) -> String {
-  s1.to_owned() + " " + s2
+    s1.to_owned() + " " + s2
 }
 
 #[derive(DtoMapper, Debug, Default, Clone)]
@@ -17,23 +17,23 @@ fn concat_str(s1: &str, s2: &str) -> String {
   new_fields=[( "name: String", "concat_str( self.firstname.as_str(), self.lastname.as_str() )" )]
 )]
 struct User {
-  username: String,
-  password: String,
-  email: String,
-  firstname: String,
-  middle_name: Option<String>,
-  lastname: String,
-  age: u8,
+    username: String,
+    password: String,
+    email: String,
+    firstname: String,
+    middle_name: Option<String>,
+    lastname: String,
+    age: u8,
 }
 
 fn main() {
-  let user = User {
-    firstname: "Dessalines".into(),
-    lastname: "Jean Jacques".into(),
-    ..User::default()
-  };
+    let user = User {
+        firstname: "Dessalines".into(),
+        lastname: "Jean Jacques".into(),
+        ..User::default()
+    };
 
-  println!("{:?}", user);
-  let custom_dto: CustomDto = user.into();
-  println!("{:?}", custom_dto);
+    println!("{:?}", user);
+    let custom_dto: CustomDto = user.into();
+    println!("{:?}", custom_dto);
 }

--- a/examples/dto_example.rs
+++ b/examples/dto_example.rs
@@ -3,7 +3,6 @@ use dto_mapper::DtoMapper;
 #[allow(unused)]
 use std::str::FromStr;
 #[allow(unused)]
-use unstringify::unstringify;
 
 fn concat_str(s1: &str, s2: &str) -> String {
     s1.to_owned() + " " + s2

--- a/examples/dto_example.rs
+++ b/examples/dto_example.rs
@@ -1,5 +1,6 @@
 use derive_builder::Builder;
 use dto_mapper::DtoMapper;
+use serde::{Deserialize, Serialize};
 #[allow(unused)]
 use std::str::FromStr;
 #[allow(unused)]
@@ -15,6 +16,24 @@ fn concat_str(s1: &str, s2: &str) -> String {
 #[mapper( dto="CustomDto" , no_builder=true , map=[ ("email",false) ] , derive=(Debug, Clone) ,
   new_fields=[( "name: String", "concat_str( self.firstname.as_str(), self.lastname.as_str() )" )]
 )]
+#[mapper(
+    dto="CustomDtoWithAttribute" ,
+    no_builder=true ,
+    map=[ ("email", false, ["#[serde(rename = \"email_address\")]"] ) ],
+    derive=(Debug, Clone, Serialize, Deserialize),
+    new_fields=[
+        (
+            "name: String",
+            "concat_str( self.firstname.as_str(), self.lastname.as_str() )",
+            ["#[serde(rename = \"full_name\")]"],
+        ),
+        (
+          "hidden_password: String",
+         r#""*".repeat( self.password.len() )"#
+        ),
+    ],
+    macro_attr=["serde(rename_all = \"UPPERCASE\")"]
+)]
 struct User {
     username: String,
     password: String,
@@ -29,10 +48,15 @@ fn main() {
     let user = User {
         firstname: "Dessalines".into(),
         lastname: "Jean Jacques".into(),
+        email: "dessalines@gmail.com".into(),
+        password: "password123".into(),
         ..User::default()
     };
 
     println!("{:?}", user);
-    let custom_dto: CustomDto = user.into();
+    let custom_dto: CustomDto = user.clone().into();
     println!("{:?}", custom_dto);
+
+    let custom_dto_attributes: CustomDtoWithAttribute = user.clone().into();
+    println!("{:?}", custom_dto_attributes);
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+# You can see more config for rustfmt --help=config
+# This confirmation is for source code formatting config used along with 'cargo fmt --verbose'
+hard_tabs = false
+tab_spaces = 4

--- a/src/dto_builder.rs
+++ b/src/dto_builder.rs
@@ -1,6 +1,6 @@
 use std::{
-  collections::{HashMap, HashSet},
-  mem,
+    collections::{HashMap, HashSet},
+    mem,
 };
 
 use ::syn::parse_str;
@@ -8,304 +8,296 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::{
-  mapper_entry::{MapValue, MapperEntry},
-  struct_entry::{FieldEntry, StructEntry},
+    mapper_entry::{MapValue, MapperEntry},
+    struct_entry::{FieldEntry, StructEntry},
 };
 
 //this is to generate the dto structure along with the fields
 pub fn generate_dto_stream(
-  mapper_entries: &Vec<MapperEntry>,
-  struct_entry: &StructEntry,
+    mapper_entries: &Vec<MapperEntry>,
+    struct_entry: &StructEntry,
 ) -> Vec<TokenStream> {
-  let dtos = mapper_entries.iter().map(|mapper_entry| {
-    let mappings = build_fields(&struct_entry, &mapper_entry);
-    let dto = format_ident!("{}", mapper_entry.dto.as_str());
+    let dtos = mapper_entries.iter().map(|mapper_entry| {
+        let mappings = build_fields(&struct_entry, &mapper_entry);
+        let dto = format_ident!("{}", mapper_entry.dto.as_str());
 
-    let derive_idents: Vec<syn::Ident> = mapper_entry
-      .derive
-      .iter()
-      .map(|derive| {
-        let ident: syn::Ident = format_ident!("{}", derive.as_str());
-        ident
-      })
-      .collect();
+        let derive_idents: Vec<syn::Ident> = mapper_entry
+            .derive
+            .iter()
+            .map(|derive| {
+                let ident: syn::Ident = format_ident!("{}", derive.as_str());
+                ident
+            })
+            .collect();
 
-    let macro_attr: Vec<_> = mapper_entry
-      .macro_attr
-      .iter()
-      .filter_map(|attr_str| {
-        let stripped = attr_str.trim_start_matches("#[").trim_end_matches("]");
-        if let Ok(meta) = syn::parse_str::<syn::Meta>(stripped) {
-          Some(syn::Attribute {
-            pound_token: syn::Token![#](proc_macro2::Span::call_site()),
-            style: syn::AttrStyle::Outer,
-            bracket_token: syn::token::Bracket(proc_macro2::Span::call_site()),
-            meta,
-          })
-        } else {
-          None
+        let macro_attr: Vec<_> = mapper_entry
+            .macro_attr
+            .iter()
+            .filter_map(|attr_str| {
+                let stripped = attr_str.trim_start_matches("#[").trim_end_matches("]");
+                if let Ok(meta) = syn::parse_str::<syn::Meta>(stripped) {
+                    Some(syn::Attribute {
+                        pound_token: syn::Token![#](proc_macro2::Span::call_site()),
+                        style: syn::AttrStyle::Outer,
+                        bracket_token: syn::token::Bracket(proc_macro2::Span::call_site()),
+                        meta,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        // eprintln!("==================>");
+        // eprintln!("source_macro_attr={:#?}", mapper_entry.macro_attr);
+        // eprintln!("parsed_macro_attr={:#?}", macro_attr);
+        if !mapper_entry.no_builder {
+            return quote! {
+                #[derive( #(#derive_idents),* )]
+                #[builder(default)]
+                #(#macro_attr)*
+                pub struct #dto {
+                    #(#mappings),*
+                }
+            };
         }
-      })
-      .collect();
-    // eprintln!("==================>");
-    // eprintln!("source_macro_attr={:#?}", mapper_entry.macro_attr);
-    // eprintln!("parsed_macro_attr={:#?}", macro_attr);
-    if !mapper_entry.no_builder {
-      return quote! {
-          #[derive( #(#derive_idents),* )]
-          #[builder(default)]
-          #(#macro_attr)*
-          pub struct #dto {
-              #(#mappings),*
-          }
-      };
-    }
 
-    //if no_builder=true return without a builder
-    return quote! {
-         #[derive( #(#derive_idents),* )]
-        #(#macro_attr)*
-        pub struct #dto {
-            #(#mappings),*
-        }
-    };
-  });
+        //if no_builder=true return without a builder
+        return quote! {
+             #[derive( #(#derive_idents),* )]
+            #(#macro_attr)*
+            pub struct #dto {
+                #(#mappings),*
+            }
+        };
+    });
 
-  dtos.collect()
+    dtos.collect()
 }
 
 //this is to build the implementation of Into trait for Dto and original structure
 pub fn generate_impl(
-  mapper_entries: &Vec<MapperEntry>,
-  struct_entry: &StructEntry,
-  is_dto: bool,
+    mapper_entries: &Vec<MapperEntry>,
+    struct_entry: &StructEntry,
+    is_dto: bool,
 ) -> Vec<TokenStream> {
-  let impls: Vec<TokenStream> = mapper_entries
-    .iter()
-    .map(|mp_entry| {
-      let mut init_fields = build_into_fields(&struct_entry, &mp_entry, is_dto);
-      if is_dto {
-        init_fields.extend(build_init_new_fields_token(&mp_entry));
-      }
-
-      let impl_stream: TokenStream;
-      let struct_name = format_ident!("{}", &struct_entry.name.as_str());
-      let dto = format_ident!("{}", mp_entry.dto.as_str());
-
-      if is_dto {
-        //convert struct into dto
-        impl_stream = quote! {
-            impl Into<#dto> for #struct_name{
-                fn into(self) -> #dto {
-                    #dto {
-                        #(#init_fields),*
-                    }
-                }
+    let impls: Vec<TokenStream> = mapper_entries
+        .iter()
+        .map(|mp_entry| {
+            let mut init_fields = build_into_fields(&struct_entry, &mp_entry, is_dto);
+            if is_dto {
+                init_fields.extend(build_init_new_fields_token(&mp_entry));
             }
-        };
-      } else {
-        //convert dto into original struct
-        impl_stream = quote! {
-            impl Into<#struct_name> for #dto{
-                fn into(self) -> #struct_name {
-                    #struct_name {
-                        #(#init_fields),* ,
-                        ..#struct_name::default()
-                    }
-                }
-            }
-        };
-      }
-      //println!("#######dto_impls = {}",impl_stream.to_string());
-      impl_stream
-    })
-    .collect();
 
-  impls
+            let impl_stream: TokenStream;
+            let struct_name = format_ident!("{}", &struct_entry.name.as_str());
+            let dto = format_ident!("{}", mp_entry.dto.as_str());
+
+            if is_dto {
+                //convert struct into dto
+                impl_stream = quote! {
+                    impl Into<#dto> for #struct_name{
+                        fn into(self) -> #dto {
+                            #dto {
+                                #(#init_fields),*
+                            }
+                        }
+                    }
+                };
+            } else {
+                //convert dto into original struct
+                impl_stream = quote! {
+                    impl Into<#struct_name> for #dto{
+                        fn into(self) -> #struct_name {
+                            #struct_name {
+                                #(#init_fields),* ,
+                                ..#struct_name::default()
+                            }
+                        }
+                    }
+                };
+            }
+            //println!("#######dto_impls = {}",impl_stream.to_string());
+            impl_stream
+        })
+        .collect();
+
+    impls
 }
 
 //this is a fundamental function to build the fields for Into trait traits such as field1 : field2
 fn build_into_fields(
-  st_entry: &StructEntry,
-  mp_entry: &MapperEntry,
-  is_dto: bool,
+    st_entry: &StructEntry,
+    mp_entry: &MapperEntry,
+    is_dto: bool,
 ) -> Vec<TokenStream> {
-  //we retrieve a hashmap of MapValue with key=source_field_name in the struct , and the the value as MapValue
-  let map_fields = get_map_of_mapvalue(mp_entry);
+    //we retrieve a hashmap of MapValue with key=source_field_name in the struct , and the the value as MapValue
+    let map_fields = get_map_of_mapvalue(mp_entry);
 
-  // Let us retrieve the ignore fields
-  let ignore_fields = get_ignore_fields(mp_entry);
+    // Let us retrieve the ignore fields
+    let ignore_fields = get_ignore_fields(mp_entry);
 
-  // let selected_fields =
-  //   get_selected_fields(&st_entry, &ignore_fields, &map_fields);
-  let selected_fields =
-    if mp_entry.exactly && map_fields.len() == 0 && ignore_fields.len() == 0 {
-      get_all_fields(&st_entry)
+    // let selected_fields =
+    //   get_selected_fields(&st_entry, &ignore_fields, &map_fields);
+    let selected_fields = if mp_entry.exactly && map_fields.len() == 0 && ignore_fields.len() == 0 {
+        get_all_fields(&st_entry)
     } else {
-      get_selected_fields(&st_entry, &ignore_fields, &map_fields)
+        get_selected_fields(&st_entry, &ignore_fields, &map_fields)
     };
 
-  selected_fields
-    .iter()
-    .map(|field| {
-      let mut name = format!("{}", field.field_name.to_string());
-      //first we assume that is_dto = true  (building initialization macro for dto init field for Into trait)
-      // build fields for initialization such that #left_name = self.#right_name
-      //the right_name contains the struct field value
-      let mut right_name = format_ident!("{}", name.as_str());
-      // the left_name has the target dto field_name which will hold the value of right_name;
-      let mut left_name = right_name.clone();
-      //Let's check if the dto field(left_name) has been renamed
-      if let Some(m_value) = map_fields.get(&name) {
-        //let's rename the struct field if there is a mapping for it
-        if let Some(ref new_name) = m_value.to_field {
-          name = new_name.clone();
-          left_name = format_ident!("{}", name.as_str());
-        }
+    selected_fields
+        .iter()
+        .map(|field| {
+            let mut name = format!("{}", field.field_name.to_string());
+            //first we assume that is_dto = true  (building initialization macro for dto init field for Into trait)
+            // build fields for initialization such that #left_name = self.#right_name
+            //the right_name contains the struct field value
+            let mut right_name = format_ident!("{}", name.as_str());
+            // the left_name has the target dto field_name which will hold the value of right_name;
+            let mut left_name = right_name.clone();
+            //Let's check if the dto field(left_name) has been renamed
+            if let Some(m_value) = map_fields.get(&name) {
+                //let's rename the struct field if there is a mapping for it
+                if let Some(ref new_name) = m_value.to_field {
+                    name = new_name.clone();
+                    left_name = format_ident!("{}", name.as_str());
+                }
 
-        //if build into is not for a dto but for a struct, let's swap left and right
-        if !is_dto {
-          mem::swap(&mut right_name, &mut left_name);
-        }
+                //if build into is not for a dto but for a struct, let's swap left and right
+                if !is_dto {
+                    mem::swap(&mut right_name, &mut left_name);
+                }
 
-        // if m_value.required = false(Option) , field.is_optional = false (straight_value)
-        let is_optional = !m_value.required && !field.is_optional;
+                // if m_value.required = false(Option) , field.is_optional = false (straight_value)
+                let is_optional = !m_value.required && !field.is_optional;
 
-        if is_dto && is_optional {
-          return quote! { #left_name: Some(self.#right_name) };
-        } else if !is_dto && is_optional {
-          return quote! { #left_name: self.#right_name.unwrap_or_default() };
-        }
-      }
+                if is_dto && is_optional {
+                    return quote! { #left_name: Some(self.#right_name) };
+                } else if !is_dto && is_optional {
+                    return quote! { #left_name: self.#right_name.unwrap_or_default() };
+                }
+            }
 
-      quote! { #left_name: self.#right_name}
-    })
-    .collect()
+            quote! { #left_name: self.#right_name}
+        })
+        .collect()
 }
 
-fn build_fields(
-  st_entry: &StructEntry,
-  mp_entry: &MapperEntry,
-) -> Vec<TokenStream> {
-  //we retrieve a hashmap of MapValue with key=source_field_name in the struct , and the the value as MapValue
-  let map_fields = get_map_of_mapvalue(mp_entry);
+fn build_fields(st_entry: &StructEntry, mp_entry: &MapperEntry) -> Vec<TokenStream> {
+    //we retrieve a hashmap of MapValue with key=source_field_name in the struct , and the the value as MapValue
+    let map_fields = get_map_of_mapvalue(mp_entry);
 
-  // Let us retrieve the ignore fields
-  let ignore_fields = get_ignore_fields(mp_entry);
+    // Let us retrieve the ignore fields
+    let ignore_fields = get_ignore_fields(mp_entry);
 
-  let selected_fields =
-    if mp_entry.exactly && map_fields.len() == 0 && ignore_fields.len() == 0 {
-      get_all_fields(&st_entry)
+    let selected_fields = if mp_entry.exactly && map_fields.len() == 0 && ignore_fields.len() == 0 {
+        get_all_fields(&st_entry)
     } else {
-      get_selected_fields(&st_entry, &ignore_fields, &map_fields)
+        get_selected_fields(&st_entry, &ignore_fields, &map_fields)
     };
 
-  let tk_stream_iterator = selected_fields.iter().map(|field| {
-    let mut name = format!("{}", field.field_name.to_string());
-    let mut name_ident = format_ident!("{}", name.as_str());
+    let tk_stream_iterator = selected_fields.iter().map(|field| {
+        let mut name = format!("{}", field.field_name.to_string());
+        let mut name_ident = format_ident!("{}", name.as_str());
 
-    let ty = &field.field_type;
-    if let Some(m_value) = map_fields.get(&name) {
-      //let's rename the struct field if there is a mapping for it
-      if let Some(ref new_name) = m_value.to_field {
-        name = new_name.clone();
-        name_ident = format_ident!("{}", name.as_str())
-      }
+        let ty = &field.field_type;
+        if let Some(m_value) = map_fields.get(&name) {
+            //let's rename the struct field if there is a mapping for it
+            if let Some(ref new_name) = m_value.to_field {
+                name = new_name.clone();
+                name_ident = format_ident!("{}", name.as_str())
+            }
 
-      if !m_value.required && !field.is_optional {
-        return quote! { pub #name_ident: Option<#ty> };
-      }
-    }
+            if !m_value.required && !field.is_optional {
+                return quote! { pub #name_ident: Option<#ty> };
+            }
+        }
 
-    quote! { pub #name_ident: #ty }
-  });
+        quote! { pub #name_ident: #ty }
+    });
 
-  let mut struct_fields = tk_stream_iterator.collect::<Vec<TokenStream>>();
-  let new_field_token = build_new_fields_token(&mp_entry);
-  // eprintln!("New Fields token = {:#?}", new_field_token);
-  struct_fields.extend(new_field_token);
+    let mut struct_fields = tk_stream_iterator.collect::<Vec<TokenStream>>();
+    let new_field_token = build_new_fields_token(&mp_entry);
+    // eprintln!("New Fields token = {:#?}", new_field_token);
+    struct_fields.extend(new_field_token);
 
-  struct_fields
+    struct_fields
 }
 
 fn build_new_fields_token(mp_entry: &MapperEntry) -> Vec<TokenStream> {
-  mp_entry
-    .new_fields
-    .iter()
-    .map(|new_field| {
-      let new_field_ident = format_ident!("{}", new_field.field_name.as_str());
-      let field_type: syn::Type = parse_str(&new_field.field_type)
-        .unwrap_or_else(|_| {
-          panic!("Failed to parse type: {}", new_field.field_type)
-        });
-
-      let attributes: Vec<TokenStream> = new_field
-        .attributes
+    mp_entry
+        .new_fields
         .iter()
-        .map(|attr| parse_str(attr).unwrap())
-        .collect();
+        .map(|new_field| {
+            let new_field_ident = format_ident!("{}", new_field.field_name.as_str());
+            let field_type: syn::Type = parse_str(&new_field.field_type)
+                .unwrap_or_else(|_| panic!("Failed to parse type: {}", new_field.field_type));
 
-      quote! {
-          #(#attributes)*
-          pub #new_field_ident: #field_type
-      }
-    })
-    .collect()
+            let attributes: Vec<TokenStream> = new_field
+                .attributes
+                .iter()
+                .map(|attr| parse_str(attr).unwrap())
+                .collect();
+
+            quote! {
+                #(#attributes)*
+                pub #new_field_ident: #field_type
+            }
+        })
+        .collect()
 }
 
 fn build_init_new_fields_token(mp_entry: &MapperEntry) -> Vec<TokenStream> {
-  mp_entry
-    .new_fields
-    .iter()
-    .map(|new_field| {
-      let name = format_ident!("{}", new_field.field_name.as_str());
-      let expr = &new_field.expression_value;
-      // let f_type = &new_field.field_type;
+    mp_entry
+        .new_fields
+        .iter()
+        .map(|new_field| {
+            let name = format_ident!("{}", new_field.field_name.as_str());
+            let expr = &new_field.expression_value;
+            // let f_type = &new_field.field_type;
 
-      // eprintln!("required = {:#?}", new_field.required);
-      // eprintln!("expr = {:#?}", expr);
-      // eprintln!("f_type = {:#?}", f_type);
+            // eprintln!("required = {:#?}", new_field.required);
+            // eprintln!("expr = {:#?}", expr);
+            // eprintln!("f_type = {:#?}", f_type);
 
-      quote! { #name: unstringify!(#expr) }
-    })
-    .collect()
+            quote! { #name: unstringify!(#expr) }
+        })
+        .collect()
 }
 
 fn get_ignore_fields(mp_entry: &MapperEntry) -> HashSet<String> {
-  let ignore_fields: HashSet<String> = mp_entry
-    .ignore
-    .iter()
-    .map(|elem| elem.to_string())
-    .collect();
-  ignore_fields
+    let ignore_fields: HashSet<String> = mp_entry
+        .ignore
+        .iter()
+        .map(|elem| elem.to_string())
+        .collect();
+    ignore_fields
 }
 
 fn get_selected_fields(
-  st_entry: &StructEntry,
-  ignore_fields: &HashSet<String>,
-  map_fields: &HashMap<String, MapValue>,
+    st_entry: &StructEntry,
+    ignore_fields: &HashSet<String>,
+    map_fields: &HashMap<String, MapValue>,
 ) -> Vec<FieldEntry> {
-  let is_ignore = ignore_fields.len() > 0;
-  st_entry
-    .field_entries
-    .iter()
-    .filter(|&field| {
-      (is_ignore && !ignore_fields.contains(&field.field_name.to_string()))
-        || (!is_ignore
-          && map_fields.contains_key(&field.field_name.to_string()))
-    })
-    .map(|f| f.clone())
-    .collect()
+    let is_ignore = ignore_fields.len() > 0;
+    st_entry
+        .field_entries
+        .iter()
+        .filter(|&field| {
+            (is_ignore && !ignore_fields.contains(&field.field_name.to_string()))
+                || (!is_ignore && map_fields.contains_key(&field.field_name.to_string()))
+        })
+        .map(|f| f.clone())
+        .collect()
 }
 
 fn get_all_fields(st_entry: &StructEntry) -> Vec<FieldEntry> {
-  st_entry.field_entries.iter().map(|f| f.clone()).collect()
+    st_entry.field_entries.iter().map(|f| f.clone()).collect()
 }
 
 fn get_map_of_mapvalue(mp_entry: &MapperEntry) -> HashMap<String, MapValue> {
-  let mut map_fields: HashMap<String, MapValue> = HashMap::new();
-  mp_entry.map.iter().for_each(|mp_val| {
-    map_fields.insert(mp_val.from_field.to_string(), mp_val.clone());
-  });
-  map_fields
+    let mut map_fields: HashMap<String, MapValue> = HashMap::new();
+    mp_entry.map.iter().for_each(|mp_val| {
+        map_fields.insert(mp_val.from_field.to_string(), mp_val.clone());
+    });
+    map_fields
 }

--- a/src/dto_builder.rs
+++ b/src/dto_builder.rs
@@ -272,14 +272,24 @@ fn build_init_new_fields_token(mp_entry: &MapperEntry) -> Vec<TokenStream> {
         .iter()
         .map(|new_field| {
             let name = format_ident!("{}", new_field.field_name.as_str());
-            let expr = &new_field.expression_value;
+            //let expr = &new_field.expression_value;
+            let expr: syn::Expr = match parse_str(new_field.expression_value.as_str()) {
+                Ok(assign_expr) => assign_expr,
+                Err(expr_error) => {
+                    //eprintln!("Failed to parse expression value {} : {}", new_field.expression_value, expr_error);
+                    panic!(
+                        r#"Failed to parse new field '{}' expression value "{}" : {}"#,
+                        new_field.field_name, new_field.expression_value, expr_error
+                    );
+                }
+            };
             // let f_type = &new_field.field_type;
 
             // eprintln!("required = {:#?}", new_field.required);
             // eprintln!("expr = {:#?}", expr);
             // eprintln!("f_type = {:#?}", f_type);
 
-            quote! { #name: unstringify!(#expr) }
+            quote! { #name: #expr }
         })
         .collect()
 }

--- a/src/entry_validator.rs
+++ b/src/entry_validator.rs
@@ -1,6 +1,6 @@
 use std::{
-  collections::{HashMap, HashSet},
-  ops::Add,
+    collections::{HashMap, HashSet},
+    ops::Add,
 };
 
 use crate::{mapper_entry::MapperEntry, struct_entry::StructEntry};
@@ -8,186 +8,176 @@ use crate::{mapper_entry::MapperEntry, struct_entry::StructEntry};
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum FieldError {
-  DupField(String),
-  MissingField(String),
+    DupField(String),
+    MissingField(String),
 }
 
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum ValidationError {
-  MapperEntryError(Vec<FieldError>),
-  StructEntryError(Vec<FieldError>),
-  DtoNameDuplicated(Vec<String>),
-  MissingPropertyError(String),
+    MapperEntryError(Vec<FieldError>),
+    StructEntryError(Vec<FieldError>),
+    DtoNameDuplicated(Vec<String>),
+    MissingPropertyError(String),
 }
 
 pub fn validate_entry_data(
-  st_entry: &StructEntry,
-  mp_entries: &Vec<MapperEntry>,
+    st_entry: &StructEntry,
+    mp_entries: &Vec<MapperEntry>,
 ) -> Result<(), ValidationError> {
-  validate_mapper_entries(&mp_entries)?;
-  validate_struct_entry(st_entry, &mp_entries)?;
-  validate_dto_name(&mp_entries)?;
-  validate_map_ignore(&mp_entries)?;
-  Ok(())
+    validate_mapper_entries(&mp_entries)?;
+    validate_struct_entry(st_entry, &mp_entries)?;
+    validate_dto_name(&mp_entries)?;
+    validate_map_ignore(&mp_entries)?;
+    Ok(())
 }
 
-fn validate_map_ignore(
-  mp_entries: &Vec<MapperEntry>,
-) -> Result<(), ValidationError> {
-  //There should be at least a map attribute or an ignore attribute per mapper entry
-  // valid mapper entry = ignore.len() > 0 || map.len() > 0
-  // invalid mapper entry = ignore.len() == 0 and map.len()==0
-  // except if they has exactly=true
-  let invalid_entries: Vec<String> = mp_entries
-    .iter()
-    .filter(|mp_entry| {
-      return mp_entry.map.len() == 0
-        && mp_entry.ignore.len() == 0
-        && mp_entry.exactly == false;
-    })
-    .map(|mp_entry| mp_entry.dto.to_string())
-    .collect();
+fn validate_map_ignore(mp_entries: &Vec<MapperEntry>) -> Result<(), ValidationError> {
+    //There should be at least a map attribute or an ignore attribute per mapper entry
+    // valid mapper entry = ignore.len() > 0 || map.len() > 0
+    // invalid mapper entry = ignore.len() == 0 and map.len()==0
+    // except if they has exactly=true
+    let invalid_entries: Vec<String> = mp_entries
+        .iter()
+        .filter(|mp_entry| {
+            return mp_entry.map.len() == 0
+                && mp_entry.ignore.len() == 0
+                && mp_entry.exactly == false;
+        })
+        .map(|mp_entry| mp_entry.dto.to_string())
+        .collect();
 
-  if invalid_entries.len() > 0 {
-    return Err(ValidationError::MissingPropertyError(
-      "mapper requires a `map` or an `ignore` property".to_string(),
-    ));
-  }
+    if invalid_entries.len() > 0 {
+        return Err(ValidationError::MissingPropertyError(
+            "mapper requires a `map` or an `ignore` property".to_string(),
+        ));
+    }
 
-  Ok(())
+    Ok(())
 }
 
-fn validate_dto_name(
-  mp_entries: &Vec<MapperEntry>,
-) -> Result<(), ValidationError> {
-  let mut dto_hash: HashMap<String, u8> = HashMap::new();
-  mp_entries.iter().for_each(|mp_entry| {
-    if let Some((ref key, ref count)) = dto_hash.get_key_value(&mp_entry.dto) {
-      dto_hash.insert(key.to_string(), count.add(1))
-    } else {
-      dto_hash.insert(mp_entry.dto.to_string(), 1)
-    };
-  });
+fn validate_dto_name(mp_entries: &Vec<MapperEntry>) -> Result<(), ValidationError> {
+    let mut dto_hash: HashMap<String, u8> = HashMap::new();
+    mp_entries.iter().for_each(|mp_entry| {
+        if let Some((ref key, ref count)) = dto_hash.get_key_value(&mp_entry.dto) {
+            dto_hash.insert(key.to_string(), count.add(1))
+        } else {
+            dto_hash.insert(mp_entry.dto.to_string(), 1)
+        };
+    });
 
-  let dto_dup: Vec<String> = map_hashmap_to_vec_string(&mut dto_hash);
-  if dto_dup.len() > 0 {
-    return Err(ValidationError::DtoNameDuplicated(dto_dup));
-  }
-  Ok(())
+    let dto_dup: Vec<String> = map_hashmap_to_vec_string(&mut dto_hash);
+    if dto_dup.len() > 0 {
+        return Err(ValidationError::DtoNameDuplicated(dto_dup));
+    }
+    Ok(())
 }
 
-fn map_hashmap_to_vec_string(
-  dto_hash: &mut HashMap<String, u8>,
-) -> Vec<String> {
-  dto_hash
-    .iter()
-    .filter(|(ref _k, &val)| val > 1)
-    .map(|(ref dto_val, &_)| dto_val.to_string())
-    .collect()
+fn map_hashmap_to_vec_string(dto_hash: &mut HashMap<String, u8>) -> Vec<String> {
+    dto_hash
+        .iter()
+        .filter(|(ref _k, &val)| val > 1)
+        .map(|(ref dto_val, &_)| dto_val.to_string())
+        .collect()
 }
 
 fn validate_struct_entry(
-  st_entry: &StructEntry,
-  mp_entries: &Vec<MapperEntry>,
+    st_entry: &StructEntry,
+    mp_entries: &Vec<MapperEntry>,
 ) -> Result<(), ValidationError> {
-  //extract a hashset of the fields name from the struct
-  let field_set: HashSet<String> = st_entry
-    .field_entries
-    .iter()
-    .map(|f| f.field_name.as_str().to_string())
-    .collect();
+    //extract a hashset of the fields name from the struct
+    let field_set: HashSet<String> = st_entry
+        .field_entries
+        .iter()
+        .map(|f| f.field_name.as_str().to_string())
+        .collect();
 
-  let mut errors: Vec<FieldError> = Vec::new();
-  for ref mp_entry in mp_entries {
-    let missing_fields: Vec<String> = mp_entry
-      .map
-      .iter()
-      .filter(|&mp_value| !field_set.contains(&mp_value.from_field))
-      .map(|m| m.from_field.as_str().to_string())
-      .collect();
-    if missing_fields.len() > 0 {
-      errors.push(FieldError::MissingField(format!(
+    let mut errors: Vec<FieldError> = Vec::new();
+    for ref mp_entry in mp_entries {
+        let missing_fields: Vec<String> = mp_entry
+            .map
+            .iter()
+            .filter(|&mp_value| !field_set.contains(&mp_value.from_field))
+            .map(|m| m.from_field.as_str().to_string())
+            .collect();
+        if missing_fields.len() > 0 {
+            errors.push(FieldError::MissingField(format!(
                 "{} field name doesn't exist in structure={}. List of wrong map field names : {:?}",
                 mp_entry.dto, st_entry.name, missing_fields
             )));
+        }
     }
-  }
-  //println!("Validation Error : {:?}", errors);
-  if errors.len() > 0 {
-    return Err(ValidationError::StructEntryError(errors));
-  }
-  Ok(())
+    //println!("Validation Error : {:?}", errors);
+    if errors.len() > 0 {
+        return Err(ValidationError::StructEntryError(errors));
+    }
+    Ok(())
 }
 
-fn validate_mapper_entries(
-  mp_entries: &Vec<MapperEntry>,
-) -> Result<(), ValidationError> {
-  //verify if we have duplicate field names in mp_entry for source and destination map fields
+fn validate_mapper_entries(mp_entries: &Vec<MapperEntry>) -> Result<(), ValidationError> {
+    //verify if we have duplicate field names in mp_entry for source and destination map fields
 
-  let mut errors: Vec<FieldError> = Vec::new();
+    let mut errors: Vec<FieldError> = Vec::new();
 
-  for mp_entry in mp_entries {
-    let mut from_set: HashMap<String, u8> = HashMap::new();
-    let mut to_set: HashMap<String, u8> = HashMap::new();
-    mp_entry.map.iter().for_each(|m_value| {
-      if let Some((ref key, ref count)) =
-        from_set.get_key_value(&m_value.from_field)
-      {
-        from_set.insert(key.to_string(), count.add(1));
-      } else {
-        from_set.insert(m_value.from_field.to_string(), 1);
-      }
+    for mp_entry in mp_entries {
+        let mut from_set: HashMap<String, u8> = HashMap::new();
+        let mut to_set: HashMap<String, u8> = HashMap::new();
+        mp_entry.map.iter().for_each(|m_value| {
+            if let Some((ref key, ref count)) = from_set.get_key_value(&m_value.from_field) {
+                from_set.insert(key.to_string(), count.add(1));
+            } else {
+                from_set.insert(m_value.from_field.to_string(), 1);
+            }
 
-      //if from_field is mapped to to_field
-      if let Some(ref to_field) = m_value.to_field {
-        if let Some((key, count)) = to_set.get_key_value(to_field) {
-          to_set.insert(key.to_string(), count.add(1));
-        } else {
-          to_set.insert(to_field.to_string(), 1);
+            //if from_field is mapped to to_field
+            if let Some(ref to_field) = m_value.to_field {
+                if let Some((key, count)) = to_set.get_key_value(to_field) {
+                    to_set.insert(key.to_string(), count.add(1));
+                } else {
+                    to_set.insert(to_field.to_string(), 1);
+                }
+            }
+        });
+        //println!();
+        //println!("======dto={} from_field_map={:?}",mp_entry.dto,from_set);
+        //println!("======dto={} to_field_map={:?}",mp_entry.dto,to_set);
+
+        // to_keys.len() will always be lesser than or equal to from_keys.len()
+        let dup_fields: Vec<String> = to_set
+            .iter()
+            .filter(|(ref key, &_c)| from_set.contains_key(&key.to_string()))
+            .map(|(ref key, &_c)| key.to_string())
+            .collect();
+
+        if dup_fields.len() > 0 {
+            errors.push(FieldError::DupField(format!(
+                "duplicate mapping destination keys found in dto={} entry: {:?}",
+                mp_entry.dto, dup_fields
+            )));
         }
-      }
-    });
-    //println!();
-    //println!("======dto={} from_field_map={:?}",mp_entry.dto,from_set);
-    //println!("======dto={} to_field_map={:?}",mp_entry.dto,to_set);
 
-    // to_keys.len() will always be lesser than or equal to from_keys.len()
-    let dup_fields: Vec<String> = to_set
-      .iter()
-      .filter(|(ref key, &_c)| from_set.contains_key(&key.to_string()))
-      .map(|(ref key, &_c)| key.to_string())
-      .collect();
+        let dup_from: Vec<String> = map_hashmap_to_vec_string(&mut from_set);
 
-    if dup_fields.len() > 0 {
-      errors.push(FieldError::DupField(format!(
-        "duplicate mapping destination keys found in dto={} entry: {:?}",
-        mp_entry.dto, dup_fields
-      )));
+        if dup_from.len() > 0 {
+            errors.push(FieldError::DupField(format!(
+                "duplicate source key names found in dto={} entry: {:?}",
+                mp_entry.dto, dup_from
+            )));
+        }
+
+        let dup_to: Vec<String> = map_hashmap_to_vec_string(&mut to_set);
+
+        if dup_to.len() > 0 {
+            errors.push(FieldError::DupField(format!(
+                "duplicate destination key names found in dto={} entry: {:?}",
+                mp_entry.dto, dup_to
+            )));
+        }
     }
 
-    let dup_from: Vec<String> = map_hashmap_to_vec_string(&mut from_set);
-
-    if dup_from.len() > 0 {
-      errors.push(FieldError::DupField(format!(
-        "duplicate source key names found in dto={} entry: {:?}",
-        mp_entry.dto, dup_from
-      )));
+    if errors.len() > 0 {
+        return Err(ValidationError::MapperEntryError(errors));
     }
 
-    let dup_to: Vec<String> = map_hashmap_to_vec_string(&mut to_set);
-
-    if dup_to.len() > 0 {
-      errors.push(FieldError::DupField(format!(
-        "duplicate destination key names found in dto={} entry: {:?}",
-        mp_entry.dto, dup_to
-      )));
-    }
-  }
-
-  if errors.len() > 0 {
-    return Err(ValidationError::MapperEntryError(errors));
-  }
-
-  Ok(())
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,75 +27,71 @@ use syn::{parse_macro_input, Attribute, DeriveInput};
 
 #[proc_macro_derive(DtoMapper, attributes(mapper))]
 pub fn dto_mapper_proc_macro(input: TokenStream) -> TokenStream {
-  let input = parse_macro_input!(input as DeriveInput);
-  let input = Box::new(input);
+    let input = parse_macro_input!(input as DeriveInput);
+    let input = Box::new(input);
 
-  let struct_entry = match process_struct_data(input.clone()) {
-    Ok(st_entry) => st_entry,
-    Err(error) => {
-      panic!("Failed parsing structure entry with error: {} ", error)
+    let struct_entry = match process_struct_data(input.clone()) {
+        Ok(st_entry) => st_entry,
+        Err(error) => {
+            panic!("Failed parsing structure entry with error: {} ", error)
+        }
+    };
+
+    let mapper_entries = match get_mapper_entries(input.clone()) {
+        Ok(map_entries) => map_entries,
+        Err(error) => panic!("Error parsing mapper entries : {}", error),
+    };
+
+    if let Err(error) = validate_entry_data(&struct_entry, &mapper_entries) {
+        panic!("Failed Validating mapper entries with error : {:?}", error);
     }
-  };
 
-  let mapper_entries = match get_mapper_entries(input.clone()) {
-    Ok(map_entries) => map_entries,
-    Err(error) => panic!("Error parsing mapper entries : {}", error),
-  };
+    let dtos = dto_builder::generate_dto_stream(&mapper_entries, &struct_entry);
+    let dto_stream = quote! {
+        #(#dtos)*
+    };
+    //let s= dto_builder::generate_dto_impl(& mapper_entries, & struct_entry);
+    let dto_impls = dto_builder::generate_impl(&mapper_entries, &struct_entry, true);
 
-  if let Err(error) = validate_entry_data(&struct_entry, &mapper_entries) {
-    panic!("Failed Validating mapper entries with error : {:?}", error);
-  }
+    let struct_impls = dto_builder::generate_impl(&mapper_entries, &struct_entry, false);
 
-  let dtos = dto_builder::generate_dto_stream(&mapper_entries, &struct_entry);
-  let dto_stream = quote! {
-      #(#dtos)*
-  };
-  //let s= dto_builder::generate_dto_impl(& mapper_entries, & struct_entry);
-  let dto_impls =
-    dto_builder::generate_impl(&mapper_entries, &struct_entry, true);
+    let expanded = quote! {
+        //DTOs generated
+        #dto_stream
 
-  let struct_impls =
-    dto_builder::generate_impl(&mapper_entries, &struct_entry, false);
+        #(#dto_impls)*
 
-  let expanded = quote! {
-      //DTOs generated
-      #dto_stream
+        #(#struct_impls)*
+    };
 
-      #(#dto_impls)*
-
-      #(#struct_impls)*
-  };
-
-  // println!("\n{:?}", expanded.to_string());
-  expanded.into()
+    // println!("\n{:?}", expanded.to_string());
+    expanded.into()
 }
 
 fn process_struct_data(input: Box<DeriveInput>) -> syn::Result<StructEntry> {
-  StructEntry::build_struct_entry(input)
+    StructEntry::build_struct_entry(input)
 }
 
 const MAPPER: &'static str = "mapper";
 
-fn get_mapper_entries(
-  input: Box<DeriveInput>,
-) -> syn::Result<Vec<MapperEntry>> {
-  let mapper_attrs: Vec<&Attribute> = input
-    .attrs
-    .iter()
-    .filter(|&a| a.path().is_ident(MAPPER))
-    .collect::<Vec<&Attribute>>();
+fn get_mapper_entries(input: Box<DeriveInput>) -> syn::Result<Vec<MapperEntry>> {
+    let mapper_attrs: Vec<&Attribute> = input
+        .attrs
+        .iter()
+        .filter(|&a| a.path().is_ident(MAPPER))
+        .collect::<Vec<&Attribute>>();
 
-  let mut mapper_entries: Vec<MapperEntry> = Vec::new();
+    let mut mapper_entries: Vec<MapperEntry> = Vec::new();
 
-  for attr in mapper_attrs {
-    //println!("=======MapperEntry===============");
-    let build_result = MapperEntry::build(attr);
-    if let Ok(mapper_entry) = build_result {
-      //println!("{:?}",mapper_entry);
-      mapper_entries.push(mapper_entry);
-    } else if let Err(error) = build_result {
-      panic!("Error parsing mapper entry: {:?}", error)
+    for attr in mapper_attrs {
+        //println!("=======MapperEntry===============");
+        let build_result = MapperEntry::build(attr);
+        if let Ok(mapper_entry) = build_result {
+            //println!("{:?}",mapper_entry);
+            mapper_entries.push(mapper_entry);
+        } else if let Err(error) = build_result {
+            panic!("Error parsing mapper entry: {:?}", error)
+        }
     }
-  }
-  syn::Result::Ok(mapper_entries)
+    syn::Result::Ok(mapper_entries)
 }

--- a/src/mapper_entry.rs
+++ b/src/mapper_entry.rs
@@ -1,6 +1,6 @@
 use syn::{
-  punctuated::Punctuated, spanned::Spanned, Attribute, Expr, ExprArray,
-  ExprLit, ExprTuple, Lit, Meta, Token,
+    punctuated::Punctuated, spanned::Spanned, Attribute, Expr, ExprArray, ExprLit, ExprTuple, Lit,
+    Meta, Token,
 };
 
 use crate::utils;
@@ -8,80 +8,75 @@ use crate::utils;
 pub type MapTuple = (String, bool);
 #[derive(Debug, Default)]
 pub struct MapperEntry {
-  pub dto: String,
-  pub map: Vec<MapValue>,
-  pub ignore: Vec<String>,
-  pub derive: Vec<String>,
-  pub no_builder: bool,
-  pub new_fields: Vec<NewField>,
-  pub exactly: bool,
-  pub macro_attr: Vec<String>,
+    pub dto: String,
+    pub map: Vec<MapValue>,
+    pub ignore: Vec<String>,
+    pub derive: Vec<String>,
+    pub no_builder: bool,
+    pub new_fields: Vec<NewField>,
+    pub exactly: bool,
+    pub macro_attr: Vec<String>,
 }
 
 //DataStructure for the type of mapper values found in each entry
 #[derive(Debug, Clone)]
 pub struct MapValue {
-  //Literal value are consited of properties with key=value
-  // dto="MyDto" , ignore="true"
-  pub from_field: String,
-  pub to_field: Option<String>,
-  pub required: bool,
+    //Literal value are consited of properties with key=value
+    // dto="MyDto" , ignore="true"
+    pub from_field: String,
+    pub to_field: Option<String>,
+    pub required: bool,
 }
 
 #[derive(Debug, Clone)]
 pub struct NewField {
-  pub field_name: String,
-  pub field_type: String,
-  //init_value is used compute this field value in the DTO during conversion with into()
-  pub expression_value: String,
-  pub attributes: Vec<String>,
+    pub field_name: String,
+    pub field_type: String,
+    //init_value is used compute this field value in the DTO during conversion with into()
+    pub expression_value: String,
+    pub attributes: Vec<String>,
 }
 
 impl NewField {
-  pub fn new(
-    name: &str,
-    r#type: &str,
-    init_expression: &str,
-    attr: Option<Vec<String>>,
-  ) -> Self {
-    Self {
-      field_name: name.to_string(),
-      field_type: r#type.to_string(),
-      expression_value: init_expression.to_string(),
-      attributes: attr.unwrap_or(vec![]),
+    pub fn new(name: &str, r#type: &str, init_expression: &str, attr: Option<Vec<String>>) -> Self {
+        Self {
+            field_name: name.to_string(),
+            field_type: r#type.to_string(),
+            expression_value: init_expression.to_string(),
+            attributes: attr.unwrap_or(vec![]),
+        }
     }
-  }
 }
 
 impl Default for MapValue {
-  fn default() -> Self {
-    Self {
-      from_field: "".into(),
-      to_field: None,
-      required: true,
+    fn default() -> Self {
+        Self {
+            from_field: "".into(),
+            to_field: None,
+            required: true,
+        }
     }
-  }
 }
 
 impl MapValue {
-  fn new(map_tuple: &MapTuple) -> Self {
-    let fields = map_tuple.0.as_str().split(":");
-    let fields: Vec<&str> = fields.collect();
+    fn new(map_tuple: &MapTuple) -> Self {
+        let fields = map_tuple.0.as_str().split(":");
+        let fields: Vec<&str> = fields.collect();
 
-    let from_field = fields[0].to_string();
-    let mut to_field: Option<String> = None;
-    if fields.len() > 1 && !fields[1].trim().is_empty() {
-      to_field = Some(fields[1].trim().to_string());
+        let from_field = fields[0].to_string();
+        let mut to_field: Option<String> = None;
+        if fields.len() > 1 && !fields[1].trim().is_empty() {
+            to_field = Some(fields[1].trim().to_string());
+        }
+
+        let required = map_tuple.1;
+
+        Self {
+            from_field,
+            to_field,
+            required,
+        }
     }
-
-    let required = map_tuple.1;
-
-    Self {
-      from_field,
-      to_field,
-      required,
-    }
-  }
 }
 
 const DTO: &'static str = "dto";
@@ -95,386 +90,365 @@ const EXACTLY: &'static str = "exactly";
 const MACRO_ATTR: &'static str = "macro_attr";
 
 impl MapperEntry {
-  pub fn build(attr: &Attribute) -> syn::Result<Self> {
-    let nested =
-      attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
-    //println!("nested count={:?}",nested.iter().count());
+    pub fn build(attr: &Attribute) -> syn::Result<Self> {
+        let nested = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+        //println!("nested count={:?}",nested.iter().count());
 
-    let mut mapper_entry = MapperEntry::default();
-    //Mapper will always set a Default derive
-    mapper_entry.derive.push("Default".to_string());
+        let mut mapper_entry = MapperEntry::default();
+        //Mapper will always set a Default derive
+        mapper_entry.derive.push("Default".to_string());
 
-    //dto property is required
-    let mut dto_prop: Option<String> = None;
-    nested.iter().for_each(|meta| {
-      if let Meta::NameValue(metaname) = meta {
-        let ident = metaname.path.get_ident().unwrap();
-        let keyname = utils::remove_white_space(&ident.to_string());
-        //println!("keyname={}",keyname);
+        //dto property is required
+        let mut dto_prop: Option<String> = None;
+        nested.iter().for_each(|meta| {
+            if let Meta::NameValue(metaname) = meta {
+                let ident = metaname.path.get_ident().unwrap();
+                let keyname = utils::remove_white_space(&ident.to_string());
+                //println!("keyname={}",keyname);
 
-        //if we got literal values such as keyname="value" or keyname=true
-        if let Expr::Lit(expr) = &metaname.value {
-          if keyname.eq_ignore_ascii_case(DTO) {
-            //we should read the string value
-            Self::parse_dto_attribute(&mut mapper_entry, &expr);
-            dto_prop = Some(mapper_entry.dto.to_string());
-          }
+                //if we got literal values such as keyname="value" or keyname=true
+                if let Expr::Lit(expr) = &metaname.value {
+                    if keyname.eq_ignore_ascii_case(DTO) {
+                        //we should read the string value
+                        Self::parse_dto_attribute(&mut mapper_entry, &expr);
+                        dto_prop = Some(mapper_entry.dto.to_string());
+                    }
 
-          //
-          if keyname.eq_ignore_ascii_case(WITHOUT_BUILDER) {
-            Self::parse_no_builder_attribute(&mut mapper_entry, &expr);
-          }
-          if keyname.eq_ignore_ascii_case(EXACTLY) {
-            Self::parse_exactly_attribute(&mut mapper_entry, &expr);
-          }
-        }
-
-        if let Expr::Array(expr_arr) = &metaname.value {
-          //println!("{} array has {} elements",keyname,expr_arr.elems.iter().clone().count());
-          if keyname.eq_ignore_ascii_case(MAP) {
-            //map is a vec of tuples such as map=[("f1",true),("f2",false)]
-            Self::parse_map_attribute(&mut mapper_entry, expr_arr);
-          }
-
-          if keyname.eq_ignore_ascii_case(NEW_FIELDS) {
-            Self::parse_new_fields_attribute(&mut mapper_entry, expr_arr);
-          }
-          if keyname.eq_ignore_ascii_case(&MACRO_ATTR) {
-            Self::parse_macro_attr_attribute(&mut mapper_entry, expr_arr);
-          }
-
-          if keyname.eq_ignore_ascii_case(IGNORE) {
-            //ignore is a vec of string such as ignore=["val1","val2"]
-            Self::parse_ignore_attribute(&mut mapper_entry, expr_arr);
-          }
-        }
-
-        if let Expr::Tuple(tuple_expr) = &metaname.value {
-          //println!("keyname {} is Tuple of literal value",keyname);
-          if keyname.eq_ignore_ascii_case(DERIVE) {
-            Self::parse_derive_attribute(&mut mapper_entry, tuple_expr);
-          }
-        }
-      }
-    });
-
-    //dto property is required and must be checked
-    match dto_prop {
-      Some(val) if utils::isblank(&val) => {
-        Err(syn::Error::new(
-          attr.span(),
-          "`dto` property is blank. It must not have whitespace",
-        ))
-      }
-      None => {
-        Err(syn::Error::new(
-          attr.span(),
-          "`dto` property is missing.It is required for mapper",
-        ))
-      }
-      _ => syn::Result::Ok(mapper_entry),
-    }
-  }
-
-  fn parse_no_builder_attribute(
-    mapper_entry: &mut MapperEntry,
-    expr: &&ExprLit,
-  ) {
-    if let Lit::Bool(lit_bool) = &expr.lit {
-      mapper_entry.no_builder = lit_bool.value();
-    }
-  }
-
-  fn parse_exactly_attribute(mapper_entry: &mut MapperEntry, expr: &&ExprLit) {
-    if let Lit::Bool(lit_bool) = &expr.lit {
-      mapper_entry.exactly = lit_bool.value();
-    }
-  }
-
-  fn parse_derive_attribute(
-    mapper_entry: &mut MapperEntry,
-    tuple_expr: &ExprTuple,
-  ) {
-    let derive_items = tuple_expr
-      .elems
-      .iter()
-      .map(|elem_expr| {
-        if let Expr::Path(path_exp) = &elem_expr {
-          let ident = path_exp.path.get_ident().unwrap();
-          let derive_obj: String = ident.to_string();
-          derive_obj
-        } else {
-          "".to_string()
-        }
-      })
-      .collect::<Vec<String>>();
-
-    //Adding a builder by default if property isn't explicitly set to true
-    if !mapper_entry.no_builder {
-      mapper_entry.derive.push("Builder".into());
-    }
-
-    derive_items
-      .iter()
-      .filter(|&val| !val.eq("Default"))
-      .map(|val| val.clone())
-      .for_each(|val| mapper_entry.derive.push(val));
-  }
-
-  fn parse_dto_attribute(mapper_entry: &mut MapperEntry, expr: &ExprLit) {
-    if let Lit::Str(lit_str) = &expr.lit {
-      //println!("{}={}",keyname,lit_str.value())
-      mapper_entry.dto = lit_str.value();
-    }
-  }
-
-  fn parse_ignore_attribute(
-    mapper_entry: &mut MapperEntry,
-    expr_arr: &ExprArray,
-  ) {
-    let ignore_arr = Self::parse_array_of_string(expr_arr);
-    //println!("{}={:?}",keyname, ignore_arr);
-    //check if matt attribute is blank
-    if ignore_arr
-      .iter()
-      .filter(|&text| utils::isblank(text))
-      .count()
-      > 0
-    {
-      panic!("`{}` attribute must not be blank", IGNORE);
-    };
-    mapper_entry.ignore = ignore_arr;
-  }
-
-  fn parse_new_fields_attribute(
-    mapper_entry: &mut MapperEntry,
-    expr_arr: &ExprArray,
-  ) {
-    mapper_entry.new_fields = Self::parse_array_of_new_fields(expr_arr);
-    //println!("{:?}",mapper_entry.new_fields);
-    if mapper_entry.new_fields.len() == 0 {
-      panic!(
-        "`{}` attribute must not be empty or have odd number of elements",
-        NEW_FIELDS
-      );
-    };
-  }
-
-  fn parse_macro_attr_attribute(
-    mapper_entry: &mut MapperEntry,
-    expr_arr: &ExprArray,
-  ) {
-    mapper_entry.macro_attr = Self::parse_array_of_macro_attr(expr_arr);
-    //println!("{:?}",mapper_entry.new_fields);
-  }
-
-  fn parse_map_attribute(mapper_entry: &mut MapperEntry, expr_arr: &ExprArray) {
-    let map_tuples = Self::parse_array_of_tuple(expr_arr);
-    //println!("{}={:?}",keyname,map_tuple);
-    mapper_entry.map = map_tuples.iter().map(MapValue::new).collect();
-    if mapper_entry
-      .map
-      .iter()
-      .filter(|&m_val| utils::isblank(&m_val.from_field))
-      .count()
-      > 0
-    {
-      panic!("`{}` attribute must not be blank", MAP);
-    };
-  }
-
-  fn parse_array_of_macro_attr(expr_arr: &syn::ExprArray) -> Vec<String> {
-    let mut vec_tuple: Vec<String> = Vec::new();
-
-    for elem in expr_arr.elems.iter() {
-      Self::process_macro_attr(&mut vec_tuple, elem);
-    }
-
-    return vec_tuple;
-  }
-  fn process_macro_attr(vec_array: &mut Vec<String>, elem: &Expr) {
-    if let Expr::Lit(content_lit) = elem {
-      // eprintln!("content_lit={:?}", content_lit);
-      if let Lit::Str(content) = &content_lit.lit {
-        vec_array.push(utils::remove_white_space(&content.value()).into());
-      }
-    }
-    // eprintln!("================>");
-    // eprintln!("vec_arr={:#?}", vec_array);
-    // eprintln!("elem={:#?}", elem);
-  }
-
-  fn parse_array_of_tuple(expr_arr: &syn::ExprArray) -> Vec<MapTuple> {
-    let mut vec_tuple: Vec<(String, bool)> = Vec::new();
-
-    for elem in expr_arr.elems.iter() {
-      if let Expr::Tuple(el_exp) = elem {
-        //println!("{} content  is a Tuple",keyname);
-        let mut str_val: Option<String> = None;
-        let mut flag: Option<bool> = None;
-        for content_expr in el_exp.elems.iter() {
-          if let Expr::Lit(content_lit) = content_expr {
-            if let Lit::Str(content) = &content_lit.lit {
-              //print!("valueStr={}",content.value());
-              str_val = utils::remove_white_space(&content.value()).into();
-            }
-
-            if let Lit::Bool(content) = &content_lit.lit {
-              //print!("  valueBool={}",content.value());
-              flag = content.value.into();
-            }
-          }
-        }
-
-        if str_val.is_some() && flag.is_some() {
-          let tuple: MapTuple = (str_val.unwrap(), flag.unwrap());
-          vec_tuple.push(tuple);
-        }
-        //println!("");
-      }
-    }
-
-    return vec_tuple;
-  }
-
-  fn parse_array_of_new_fields(expr_arr: &syn::ExprArray) -> Vec<NewField> {
-    let mut vec_tuple: Vec<NewField> = Vec::new();
-
-    for elem in expr_arr.elems.iter() {
-      Self::process_new_fields(&mut vec_tuple, elem);
-    }
-
-    return vec_tuple;
-  }
-
-  fn process_new_fields(mut vec_tuple: &mut Vec<NewField>, elem: &Expr) {
-    if let Expr::Tuple(el_exp) = elem {
-      let mut field_data: [Option<String>; 2] = [None, None];
-      let mut attributes: Vec<String> = Vec::new();
-      let total_passed_args = el_exp.elems.len();
-
-      // eprintln!("===========>");
-      // eprintln!("elem= {:#?}", el_exp.elems);
-      // eprintln!("attrs= {:#?}", el_exp.attrs);
-      // eprintln!("vec_tuple= {:#?}", vec_tuple);
-
-      for (position, content_expr) in el_exp.elems.iter().enumerate() {
-        // eprintln!("content_expr={:#?}", content_expr);
-        // eprintln!("position={}", position);
-        match position % 4 {
-          0 | 1 => {
-            // Field name or value
-            if let Expr::Lit(content_lit) = content_expr {
-              if let Lit::Str(content) = &content_lit.lit {
-                if let Some(str_val) =
-                  utils::remove_white_space(&content.value()).into()
-                {
-                  // eprintln!("str_val={}", str_val);
-                  field_data[position % 2] = Some(str_val);
+                    //
+                    if keyname.eq_ignore_ascii_case(WITHOUT_BUILDER) {
+                        Self::parse_no_builder_attribute(&mut mapper_entry, &expr);
+                    }
+                    if keyname.eq_ignore_ascii_case(EXACTLY) {
+                        Self::parse_exactly_attribute(&mut mapper_entry, &expr);
+                    }
                 }
-              }
-            }
-          }
-          2 => {
-            // Attributes array
-            attributes = extract_attributes(content_expr);
-            // eprintln!("attributes={:#?}", attributes);
-          }
-          _ => unreachable!(),
-        }
 
-        // Process the field when we have all provided arguments
-        if total_passed_args - 1 == position {
-          if let (Some(field_decl), Some(field_value)) =
-            (&field_data[0], &field_data[1])
-          {
-            if let Some(colon_position) = field_decl.find(":") {
-              // eprintln!("field_decl={}", field_decl);
-              // eprintln!("colon={}", colon_position);
-              Self::insert_next_field_value(
-                &mut vec_tuple,
-                field_value.clone(),
-                field_decl,
-                &colon_position,
-                if attributes.is_empty() {
-                  None
+                if let Expr::Array(expr_arr) = &metaname.value {
+                    //println!("{} array has {} elements",keyname,expr_arr.elems.iter().clone().count());
+                    if keyname.eq_ignore_ascii_case(MAP) {
+                        //map is a vec of tuples such as map=[("f1",true),("f2",false)]
+                        Self::parse_map_attribute(&mut mapper_entry, expr_arr);
+                    }
+
+                    if keyname.eq_ignore_ascii_case(NEW_FIELDS) {
+                        Self::parse_new_fields_attribute(&mut mapper_entry, expr_arr);
+                    }
+                    if keyname.eq_ignore_ascii_case(&MACRO_ATTR) {
+                        Self::parse_macro_attr_attribute(&mut mapper_entry, expr_arr);
+                    }
+
+                    if keyname.eq_ignore_ascii_case(IGNORE) {
+                        //ignore is a vec of string such as ignore=["val1","val2"]
+                        Self::parse_ignore_attribute(&mut mapper_entry, expr_arr);
+                    }
+                }
+
+                if let Expr::Tuple(tuple_expr) = &metaname.value {
+                    //println!("keyname {} is Tuple of literal value",keyname);
+                    if keyname.eq_ignore_ascii_case(DERIVE) {
+                        Self::parse_derive_attribute(&mut mapper_entry, tuple_expr);
+                    }
+                }
+            }
+        });
+
+        //dto property is required and must be checked
+        match dto_prop {
+            Some(val) if utils::isblank(&val) => Err(syn::Error::new(
+                attr.span(),
+                "`dto` property is blank. It must not have whitespace",
+            )),
+            None => Err(syn::Error::new(
+                attr.span(),
+                "`dto` property is missing.It is required for mapper",
+            )),
+            _ => syn::Result::Ok(mapper_entry),
+        }
+    }
+
+    fn parse_no_builder_attribute(mapper_entry: &mut MapperEntry, expr: &&ExprLit) {
+        if let Lit::Bool(lit_bool) = &expr.lit {
+            mapper_entry.no_builder = lit_bool.value();
+        }
+    }
+
+    fn parse_exactly_attribute(mapper_entry: &mut MapperEntry, expr: &&ExprLit) {
+        if let Lit::Bool(lit_bool) = &expr.lit {
+            mapper_entry.exactly = lit_bool.value();
+        }
+    }
+
+    fn parse_derive_attribute(mapper_entry: &mut MapperEntry, tuple_expr: &ExprTuple) {
+        let derive_items = tuple_expr
+            .elems
+            .iter()
+            .map(|elem_expr| {
+                if let Expr::Path(path_exp) = &elem_expr {
+                    let ident = path_exp.path.get_ident().unwrap();
+                    let derive_obj: String = ident.to_string();
+                    derive_obj
                 } else {
-                  Some(attributes.clone())
-                },
-              );
-            } else {
-              panic!("Missing `:` character for field declaration");
+                    "".to_string()
+                }
+            })
+            .collect::<Vec<String>>();
+
+        //Adding a builder by default if property isn't explicitly set to true
+        if !mapper_entry.no_builder {
+            mapper_entry.derive.push("Builder".into());
+        }
+
+        derive_items
+            .iter()
+            .filter(|&val| !val.eq("Default"))
+            .map(|val| val.clone())
+            .for_each(|val| mapper_entry.derive.push(val));
+    }
+
+    fn parse_dto_attribute(mapper_entry: &mut MapperEntry, expr: &ExprLit) {
+        if let Lit::Str(lit_str) = &expr.lit {
+            //println!("{}={}",keyname,lit_str.value())
+            mapper_entry.dto = lit_str.value();
+        }
+    }
+
+    fn parse_ignore_attribute(mapper_entry: &mut MapperEntry, expr_arr: &ExprArray) {
+        let ignore_arr = Self::parse_array_of_string(expr_arr);
+        //println!("{}={:?}",keyname, ignore_arr);
+        //check if matt attribute is blank
+        if ignore_arr
+            .iter()
+            .filter(|&text| utils::isblank(text))
+            .count()
+            > 0
+        {
+            panic!("`{}` attribute must not be blank", IGNORE);
+        };
+        mapper_entry.ignore = ignore_arr;
+    }
+
+    fn parse_new_fields_attribute(mapper_entry: &mut MapperEntry, expr_arr: &ExprArray) {
+        mapper_entry.new_fields = Self::parse_array_of_new_fields(expr_arr);
+        //println!("{:?}",mapper_entry.new_fields);
+        if mapper_entry.new_fields.len() == 0 {
+            panic!(
+                "`{}` attribute must not be empty or have odd number of elements",
+                NEW_FIELDS
+            );
+        };
+    }
+
+    fn parse_macro_attr_attribute(mapper_entry: &mut MapperEntry, expr_arr: &ExprArray) {
+        mapper_entry.macro_attr = Self::parse_array_of_macro_attr(expr_arr);
+        //println!("{:?}",mapper_entry.new_fields);
+    }
+
+    fn parse_map_attribute(mapper_entry: &mut MapperEntry, expr_arr: &ExprArray) {
+        let map_tuples = Self::parse_array_of_tuple(expr_arr);
+        //println!("{}={:?}",keyname,map_tuple);
+        mapper_entry.map = map_tuples.iter().map(MapValue::new).collect();
+        if mapper_entry
+            .map
+            .iter()
+            .filter(|&m_val| utils::isblank(&m_val.from_field))
+            .count()
+            > 0
+        {
+            panic!("`{}` attribute must not be blank", MAP);
+        };
+    }
+
+    fn parse_array_of_macro_attr(expr_arr: &syn::ExprArray) -> Vec<String> {
+        let mut vec_tuple: Vec<String> = Vec::new();
+
+        for elem in expr_arr.elems.iter() {
+            Self::process_macro_attr(&mut vec_tuple, elem);
+        }
+
+        return vec_tuple;
+    }
+    fn process_macro_attr(vec_array: &mut Vec<String>, elem: &Expr) {
+        if let Expr::Lit(content_lit) = elem {
+            // eprintln!("content_lit={:?}", content_lit);
+            if let Lit::Str(content) = &content_lit.lit {
+                vec_array.push(utils::remove_white_space(&content.value()).into());
             }
-          }
-          // Reset for next field
-          field_data = [None, None];
-          attributes.clear();
         }
-      }
-
-      // eprintln!("===========>");
-    }
-  }
-
-  fn insert_next_field_value(
-    vec_tuple: &mut Vec<NewField>,
-    str_val: String,
-    field_decl: &String,
-    colon_position: &usize,
-    attributes: Option<Vec<String>>,
-  ) {
-    if *colon_position == 0 {
-      panic!("`:` cannot be the first character. Need to specify new fieldname for struct");
-    }
-    if *colon_position == field_decl.len() - 1 {
-      panic!("Need to specify a type for the fieldname after `:`");
+        // eprintln!("================>");
+        // eprintln!("vec_arr={:#?}", vec_array);
+        // eprintln!("elem={:#?}", elem);
     }
 
-    let field_name = &field_decl.as_str()[..*colon_position];
-    let field_type = &field_decl.as_str()[*colon_position + 1..];
+    fn parse_array_of_tuple(expr_arr: &syn::ExprArray) -> Vec<MapTuple> {
+        let mut vec_tuple: Vec<(String, bool)> = Vec::new();
 
-    vec_tuple.push(NewField::new(
-      field_name,
-      field_type,
-      str_val.as_str(),
-      attributes,
-    ));
-  }
+        for elem in expr_arr.elems.iter() {
+            if let Expr::Tuple(el_exp) = elem {
+                //println!("{} content  is a Tuple",keyname);
+                let mut str_val: Option<String> = None;
+                let mut flag: Option<bool> = None;
+                for content_expr in el_exp.elems.iter() {
+                    if let Expr::Lit(content_lit) = content_expr {
+                        if let Lit::Str(content) = &content_lit.lit {
+                            //print!("valueStr={}",content.value());
+                            str_val = utils::remove_white_space(&content.value()).into();
+                        }
 
-  fn parse_array_of_string(expr_arr: &syn::ExprArray) -> Vec<String> {
-    let mut vec_str: Vec<String> = Vec::new();
-    for elem in expr_arr.elems.iter() {
-      if let Expr::Lit(lit_expr) = elem {
-        //println!("{} content  is a String",keyname);
-        if let Lit::Str(content) = &lit_expr.lit {
-          //fprint!("valueStr={}, ",content.value());
-          vec_str.push(utils::remove_white_space(&content.value()));
+                        if let Lit::Bool(content) = &content_lit.lit {
+                            //print!("  valueBool={}",content.value());
+                            flag = content.value.into();
+                        }
+                    }
+                }
+
+                if str_val.is_some() && flag.is_some() {
+                    let tuple: MapTuple = (str_val.unwrap(), flag.unwrap());
+                    vec_tuple.push(tuple);
+                }
+                //println!("");
+            }
         }
-      }
+
+        return vec_tuple;
     }
-    return vec_str;
-  }
+
+    fn parse_array_of_new_fields(expr_arr: &syn::ExprArray) -> Vec<NewField> {
+        let mut vec_tuple: Vec<NewField> = Vec::new();
+
+        for elem in expr_arr.elems.iter() {
+            Self::process_new_fields(&mut vec_tuple, elem);
+        }
+
+        return vec_tuple;
+    }
+
+    fn process_new_fields(mut vec_tuple: &mut Vec<NewField>, elem: &Expr) {
+        if let Expr::Tuple(el_exp) = elem {
+            let mut field_data: [Option<String>; 2] = [None, None];
+            let mut attributes: Vec<String> = Vec::new();
+            let total_passed_args = el_exp.elems.len();
+
+            // eprintln!("===========>");
+            // eprintln!("elem= {:#?}", el_exp.elems);
+            // eprintln!("attrs= {:#?}", el_exp.attrs);
+            // eprintln!("vec_tuple= {:#?}", vec_tuple);
+
+            for (position, content_expr) in el_exp.elems.iter().enumerate() {
+                // eprintln!("content_expr={:#?}", content_expr);
+                // eprintln!("position={}", position);
+                match position % 4 {
+                    0 | 1 => {
+                        // Field name or value
+                        if let Expr::Lit(content_lit) = content_expr {
+                            if let Lit::Str(content) = &content_lit.lit {
+                                if let Some(str_val) =
+                                    utils::remove_white_space(&content.value()).into()
+                                {
+                                    // eprintln!("str_val={}", str_val);
+                                    field_data[position % 2] = Some(str_val);
+                                }
+                            }
+                        }
+                    }
+                    2 => {
+                        // Attributes array
+                        attributes = extract_attributes(content_expr);
+                        // eprintln!("attributes={:#?}", attributes);
+                    }
+                    _ => unreachable!(),
+                }
+
+                // Process the field when we have all provided arguments
+                if total_passed_args - 1 == position {
+                    if let (Some(field_decl), Some(field_value)) = (&field_data[0], &field_data[1])
+                    {
+                        if let Some(colon_position) = field_decl.find(":") {
+                            // eprintln!("field_decl={}", field_decl);
+                            // eprintln!("colon={}", colon_position);
+                            Self::insert_next_field_value(
+                                &mut vec_tuple,
+                                field_value.clone(),
+                                field_decl,
+                                &colon_position,
+                                if attributes.is_empty() {
+                                    None
+                                } else {
+                                    Some(attributes.clone())
+                                },
+                            );
+                        } else {
+                            panic!("Missing `:` character for field declaration");
+                        }
+                    }
+                    // Reset for next field
+                    field_data = [None, None];
+                    attributes.clear();
+                }
+            }
+
+            // eprintln!("===========>");
+        }
+    }
+
+    fn insert_next_field_value(
+        vec_tuple: &mut Vec<NewField>,
+        str_val: String,
+        field_decl: &String,
+        colon_position: &usize,
+        attributes: Option<Vec<String>>,
+    ) {
+        if *colon_position == 0 {
+            panic!("`:` cannot be the first character. Need to specify new fieldname for struct");
+        }
+        if *colon_position == field_decl.len() - 1 {
+            panic!("Need to specify a type for the fieldname after `:`");
+        }
+
+        let field_name = &field_decl.as_str()[..*colon_position];
+        let field_type = &field_decl.as_str()[*colon_position + 1..];
+
+        vec_tuple.push(NewField::new(
+            field_name,
+            field_type,
+            str_val.as_str(),
+            attributes,
+        ));
+    }
+
+    fn parse_array_of_string(expr_arr: &syn::ExprArray) -> Vec<String> {
+        let mut vec_str: Vec<String> = Vec::new();
+        for elem in expr_arr.elems.iter() {
+            if let Expr::Lit(lit_expr) = elem {
+                //println!("{} content  is a String",keyname);
+                if let Lit::Str(content) = &lit_expr.lit {
+                    //fprint!("valueStr={}, ",content.value());
+                    vec_str.push(utils::remove_white_space(&content.value()));
+                }
+            }
+        }
+        return vec_str;
+    }
 }
 
 // Helper to extract extra attrs
 fn extract_attributes(expr: &Expr) -> Vec<String> {
-  if let Expr::Array(array_expr) = expr {
-    array_expr
-      .elems
-      .iter()
-      .filter_map(|elem| {
-        if let Expr::Lit(lit_expr) = elem {
-          if let Lit::Str(str_lit) = &lit_expr.lit {
-            Some(str_lit.value().trim().to_string())
-          } else {
-            None
-          }
-        } else {
-          None
-        }
-      })
-      .collect()
-  } else {
-    Vec::new()
-  }
+    if let Expr::Array(array_expr) = expr {
+        array_expr
+            .elems
+            .iter()
+            .filter_map(|elem| {
+                if let Expr::Lit(lit_expr) = elem {
+                    if let Lit::Str(str_lit) = &lit_expr.lit {
+                        Some(str_lit.value().trim().to_string())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        Vec::new()
+    }
 }

--- a/src/mapper_entry.rs
+++ b/src/mapper_entry.rs
@@ -155,7 +155,7 @@ impl MapperEntry {
 
         //dto property is required and must be checked
         match dto_prop {
-            Some(val) if utils::isblank(&val) => Err(syn::Error::new(
+            Some(val) if isblank(&val) => Err(syn::Error::new(
                 attr.span(),
                 "`dto` property is blank. It must not have whitespace",
             )),
@@ -163,7 +163,7 @@ impl MapperEntry {
                 attr.span(),
                 "`dto` property is missing.It is required for mapper",
             )),
-            _ => syn::Result::Ok(mapper_entry),
+            _ => Ok(mapper_entry),
         }
     }
 
@@ -217,12 +217,7 @@ impl MapperEntry {
         let ignore_arr = Self::parse_array_of_string(expr_arr);
         //println!("{}={:?}",keyname, ignore_arr);
         //check if matt attribute is blank
-        if ignore_arr
-            .iter()
-            .filter(|&text| utils::isblank(text))
-            .count()
-            > 0
-        {
+        if ignore_arr.iter().filter(|&text| isblank(text)).count() > 0 {
             panic!("`{}` attribute must not be blank", IGNORE);
         };
         mapper_entry.ignore = ignore_arr;
@@ -262,7 +257,7 @@ impl MapperEntry {
         if mapper_entry
             .map
             .iter()
-            .filter(|&m_val| utils::isblank(&m_val.from_field))
+            .filter(|&m_val| isblank(&m_val.from_field))
             .count()
             > 0
         {
@@ -270,14 +265,14 @@ impl MapperEntry {
         };
     }
 
-    fn parse_array_of_macro_attr(expr_arr: &syn::ExprArray) -> Vec<String> {
+    fn parse_array_of_macro_attr(expr_arr: &ExprArray) -> Vec<String> {
         let mut vec_tuple: Vec<String> = Vec::new();
 
         for elem in expr_arr.elems.iter() {
             Self::process_macro_attr(&mut vec_tuple, elem);
         }
 
-        return vec_tuple;
+        vec_tuple
     }
     fn process_macro_attr(vec_array: &mut Vec<String>, elem: &Expr) {
         if let Expr::Lit(content_lit) = elem {
@@ -291,7 +286,7 @@ impl MapperEntry {
         // eprintln!("elem={:#?}", elem);
     }
 
-    fn parse_array_of_tuple(expr_arr: &syn::ExprArray) -> Vec<MapTuple> {
+    fn parse_array_of_tuple(expr_arr: &ExprArray) -> Vec<MapTuple> {
         let mut vec_tuple: Vec<(String, bool)> = Vec::new();
 
         for elem in expr_arr.elems.iter() {
@@ -321,17 +316,17 @@ impl MapperEntry {
             }
         }
 
-        return vec_tuple;
+        vec_tuple
     }
 
-    fn parse_array_of_new_fields(expr_arr: &syn::ExprArray) -> Vec<NewField> {
+    fn parse_array_of_new_fields(expr_arr: &ExprArray) -> Vec<NewField> {
         let mut vec_tuple: Vec<NewField> = Vec::new();
 
         for elem in expr_arr.elems.iter() {
             Self::process_new_fields(&mut vec_tuple, elem);
         }
 
-        return vec_tuple;
+        vec_tuple
     }
 
     fn process_new_fields(mut vec_tuple: &mut Vec<NewField>, elem: &Expr) {
@@ -428,7 +423,7 @@ impl MapperEntry {
         ));
     }
 
-    fn parse_array_of_string(expr_arr: &syn::ExprArray) -> Vec<String> {
+    fn parse_array_of_string(expr_arr: &ExprArray) -> Vec<String> {
         let mut vec_str: Vec<String> = Vec::new();
         for elem in expr_arr.elems.iter() {
             if let Expr::Lit(lit_expr) = elem {
@@ -439,7 +434,7 @@ impl MapperEntry {
                 }
             }
         }
-        return vec_str;
+        vec_str
     }
 }
 

--- a/src/struct_entry.rs
+++ b/src/struct_entry.rs
@@ -4,96 +4,91 @@ use syn::{Data, DataStruct, DeriveInput, Fields};
 //A StructEntry will hold the structure name and a list(vector) of FieldEntry
 #[derive(Default)]
 pub struct StructEntry {
-  pub name: String,
-  pub field_entries: Vec<FieldEntry>,
+    pub name: String,
+    pub field_entries: Vec<FieldEntry>,
 }
 
 //FieldEntry will hold data about a field from a struct such that its name, and its type
 #[derive(Clone)]
 pub struct FieldEntry {
-  pub field_name: String,
-  pub field_type: Type,
-  pub is_optional: bool,
+    pub field_name: String,
+    pub field_type: Type,
+    pub is_optional: bool,
 }
 
 impl StructEntry {
-  pub fn build_struct_entry(input: Box<DeriveInput>) -> syn::Result<Self> {
-    let struct_name = format!("{}", input.ident);
-    let fields = if let Data::Struct(DataStruct {
-      fields: Fields::Named(syn::FieldsNamed { ref named, .. }),
-      ..
-    }) = input.data
-    {
-      named
-    } else {
-      unimplemented!("Implemented only for structure not other type")
-    };
+    pub fn build_struct_entry(input: Box<DeriveInput>) -> syn::Result<Self> {
+        let struct_name = format!("{}", input.ident);
+        let fields = if let Data::Struct(DataStruct {
+            fields: Fields::Named(syn::FieldsNamed { ref named, .. }),
+            ..
+        }) = input.data
+        {
+            named
+        } else {
+            unimplemented!("Implemented only for structure not other type")
+        };
 
-    let struct_entries: Vec<FieldEntry> = fields
-      .iter()
-      .map(|field| {
-        //let name = format!("{:?}",field.ident);
-        let name = field.clone().ident.unwrap().to_string();
+        let struct_entries: Vec<FieldEntry> = fields
+            .iter()
+            .map(|field| {
+                //let name = format!("{:?}",field.ident);
+                let name = field.clone().ident.unwrap().to_string();
 
-        let has_option = is_type_option(&field.ty);
-        //println!("field={} is_optional={}",name,has_option);
+                let has_option = is_type_option(&field.ty);
+                //println!("field={} is_optional={}",name,has_option);
 
-        FieldEntry {
-          field_name: name,
-          field_type: field.ty.clone(),
-          is_optional: has_option,
-        }
-      })
-      .collect();
-    //let struct_entry = StructEntry::default();
-    syn::Result::Ok(Self {
-      name: struct_name,
-      field_entries: struct_entries,
-    })
-  }
+                FieldEntry {
+                    field_name: name,
+                    field_type: field.ty.clone(),
+                    is_optional: has_option,
+                }
+            })
+            .collect();
+        //let struct_entry = StructEntry::default();
+        syn::Result::Ok(Self {
+            name: struct_name,
+            field_entries: struct_entries,
+        })
+    }
 }
 
 //https://github.com/jonhoo/proc-macro-workshop/blob/master/builder/src/lib.rs
 //this code snippet is inspired from the builder workshop for syn library
 //This is to figure out if type is an option
 pub fn is_type_option(a_type: &Type) -> bool {
-  if let Type::Path(ref p) = a_type {
-    if p.path.segments.len() > 0 && p.path.segments[0].ident == "Option" {
-      return true;
-    }
+    if let Type::Path(ref p) = a_type {
+        if p.path.segments.len() > 0 && p.path.segments[0].ident == "Option" {
+            return true;
+        }
 
-    return false;
-  }
-  //return false by default
-  false
+        return false;
+    }
+    //return false by default
+    false
 }
 
-fn _ty_inner_type<'a>(
-  wrapper: &str,
-  ty: &'a syn::Type,
-) -> Option<&'a syn::Type> {
-  if let syn::Type::Path(ref p) = ty {
-    //println!("segment len: {}",p.path.segments.len());
-    /*if p.path.segments.len()>0 {
-        println!("Segment Ident={}", p.path.segments[0].ident);
-    }*/
-    if p.path.segments.len() != 1 || p.path.segments[0].ident != wrapper {
-      return None;
+fn _ty_inner_type<'a>(wrapper: &str, ty: &'a syn::Type) -> Option<&'a syn::Type> {
+    if let syn::Type::Path(ref p) = ty {
+        //println!("segment len: {}",p.path.segments.len());
+        /*if p.path.segments.len()>0 {
+            println!("Segment Ident={}", p.path.segments[0].ident);
+        }*/
+        if p.path.segments.len() != 1 || p.path.segments[0].ident != wrapper {
+            return None;
+        }
+
+        if let syn::PathArguments::AngleBracketed(ref inner_ty) = p.path.segments[0].arguments {
+            if inner_ty.args.len() != 1 {
+                return None;
+            }
+
+            let inner_ty = inner_ty.args.first().unwrap();
+
+            if let syn::GenericArgument::Type(ref t) = inner_ty {
+                return Some(t);
+            }
+        }
     }
-
-    if let syn::PathArguments::AngleBracketed(ref inner_ty) =
-      p.path.segments[0].arguments
-    {
-      if inner_ty.args.len() != 1 {
-        return None;
-      }
-
-      let inner_ty = inner_ty.args.first().unwrap();
-
-      if let syn::GenericArgument::Type(ref t) = inner_ty {
-        return Some(t);
-      }
-    }
-  }
-  None
+    None
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,10 @@
 pub fn remove_white_space(str: &String) -> String {
-  str
-    .as_str()
-    .chars()
-    .filter(|c| !c.is_whitespace())
-    .collect()
+    str.as_str()
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect()
 }
 
 pub fn isblank(str: &String) -> bool {
-  remove_white_space(str).is_empty()
+    remove_white_space(str).is_empty()
 }

--- a/tests/test_dto_creation.rs
+++ b/tests/test_dto_creation.rs
@@ -1,25 +1,25 @@
 #[cfg(test)]
 mod test_dto_creation {
-  use derive_builder::Builder;
-  use dto_mapper::DtoMapper;
-  use serde::{Deserialize, Serialize};
-  #[allow(unused)]
-  use std::str::FromStr;
-  #[allow(unused)]
-  use unstringify::unstringify;
+    use derive_builder::Builder;
+    use dto_mapper::DtoMapper;
+    use serde::{Deserialize, Serialize};
+    #[allow(unused)]
+    use std::str::FromStr;
+    #[allow(unused)]
+    use unstringify::unstringify;
 
-  fn concat_str(s1: &str, s2: &str) -> String {
-    s1.to_owned() + " " + s2
-  }
+    fn concat_str(s1: &str, s2: &str) -> String {
+        s1.to_owned() + " " + s2
+    }
 
-  #[derive(DtoMapper, Debug, Default, Clone)]
-  #[mapper( dto="LoginDto"  , map=[ ("username:login",true) , ("password",true)] , derive=(Debug, Clone, PartialEq) )]
-  #[mapper( dto="ProfileDto" , ignore=["password"]  , derive=(Debug, Clone, PartialEq) )]
-  #[mapper( dto="PersonDto" , no_builder=true , map=[ ("firstname",true), ("lastname",true), ("email",false) ]  )]
-  #[mapper( dto="CustomDto" , no_builder=true , map=[ ("email",false) ] , derive=(Debug, Clone) ,
+    #[derive(DtoMapper, Debug, Default, Clone)]
+    #[mapper( dto="LoginDto"  , map=[ ("username:login",true) , ("password",true)] , derive=(Debug, Clone, PartialEq) )]
+    #[mapper( dto="ProfileDto" , ignore=["password"]  , derive=(Debug, Clone, PartialEq) )]
+    #[mapper( dto="PersonDto" , no_builder=true , map=[ ("firstname",true), ("lastname",true), ("email",false) ]  )]
+    #[mapper( dto="CustomDto" , no_builder=true , map=[ ("email",false) ] , derive=(Debug, Clone) ,
         new_fields=[( "name: String", "concat_str( self.firstname.as_str(), self.lastname.as_str() )" )]
     )]
-  #[mapper(
+    #[mapper(
     dto="CustomDtoWithAttribute" ,
     no_builder=true ,
     map=[ ("email",false) ],
@@ -31,137 +31,137 @@ mod test_dto_creation {
     )],
     macro_attr=["serde(rename_all = \"UPPERCASE\")"]
   )]
-  struct User {
-    username: String,
-    password: String,
-    email: String,
-    firstname: String,
-    middle_name: Option<String>,
-    lastname: String,
-    age: u8,
-  }
+    struct User {
+        username: String,
+        password: String,
+        email: String,
+        firstname: String,
+        middle_name: Option<String>,
+        lastname: String,
+        age: u8,
+    }
 
-  #[test]
-  fn test_multiple_dto_creation() {
-    let login_dto: LoginDto = LoginDto::default();
-    let profile_dto: ProfileDto = ProfileDto::default();
-    assert!(login_dto.login.is_empty());
-    assert!(login_dto.password.is_empty());
+    #[test]
+    fn test_multiple_dto_creation() {
+        let login_dto: LoginDto = LoginDto::default();
+        let profile_dto: ProfileDto = ProfileDto::default();
+        assert!(login_dto.login.is_empty());
+        assert!(login_dto.password.is_empty());
 
-    assert!(profile_dto.username.is_empty());
-    assert!(profile_dto.email.is_empty());
-    assert_eq!(0, profile_dto.age);
-  }
-  #[test]
-  fn test_optional_creation() {
-    let person_dto: PersonDto = PersonDto::default();
-    //email field should be of Option type
+        assert!(profile_dto.username.is_empty());
+        assert!(profile_dto.email.is_empty());
+        assert_eq!(0, profile_dto.age);
+    }
+    #[test]
+    fn test_optional_creation() {
+        let person_dto: PersonDto = PersonDto::default();
+        //email field should be of Option type
 
-    assert!(person_dto.email.is_some() || person_dto.email.is_none());
-  }
+        assert!(person_dto.email.is_some() || person_dto.email.is_none());
+    }
 
-  #[test]
-  fn test_struct_into_dto() {
-    let user = User {
-      username: "dessalines".to_string(),
-      email: "dessalines@mail.ht".to_string(),
-      password: "XXXXXXXXXXXXX".into(),
-      firstname: "Dessalines".to_string(),
-      lastname: "Jean jacques".to_string(),
-      age: 50,
-      ..User::default()
-    };
+    #[test]
+    fn test_struct_into_dto() {
+        let user = User {
+            username: "dessalines".to_string(),
+            email: "dessalines@mail.ht".to_string(),
+            password: "XXXXXXXXXXXXX".into(),
+            firstname: "Dessalines".to_string(),
+            lastname: "Jean jacques".to_string(),
+            age: 50,
+            ..User::default()
+        };
 
-    //clone user as into moves user after into() operation in order to reuse user in subsequent calls
-    let lg_dto_user: LoginDto = user.clone().into();
-    let pf_dto_user: ProfileDto = user.clone().into();
+        //clone user as into moves user after into() operation in order to reuse user in subsequent calls
+        let lg_dto_user: LoginDto = user.clone().into();
+        let pf_dto_user: ProfileDto = user.clone().into();
 
-    println!("User to LoginDto = {:?}", lg_dto_user);
-    println!("User to ProfileDto = {:?}", pf_dto_user);
-    assert_eq!(
-      LoginDto {
-        login: user.username.to_string(),
-        password: user.password,
-      },
-      lg_dto_user
-    );
-    //values of user field is being moved only for the test scenario. if used further, use .to_string()
-    assert_eq!(
-      ProfileDto {
-        username: user.username.to_string(),
-        email: user.email.to_string(),
-        firstname: user.firstname,
-        middle_name: None,
-        lastname: user.lastname,
-        age: user.age,
-      },
-      pf_dto_user
-    );
-  }
+        println!("User to LoginDto = {:?}", lg_dto_user);
+        println!("User to ProfileDto = {:?}", pf_dto_user);
+        assert_eq!(
+            LoginDto {
+                login: user.username.to_string(),
+                password: user.password,
+            },
+            lg_dto_user
+        );
+        //values of user field is being moved only for the test scenario. if used further, use .to_string()
+        assert_eq!(
+            ProfileDto {
+                username: user.username.to_string(),
+                email: user.email.to_string(),
+                firstname: user.firstname,
+                middle_name: None,
+                lastname: user.lastname,
+                age: user.age,
+            },
+            pf_dto_user
+        );
+    }
 
-  #[test]
-  fn test_dto_into_struct() {
-    let person = PersonDto {
-      firstname: "Dessalines".to_string(),
-      lastname: "Jean Jacques".to_string(),
-      email: Some("dessalines@mail.ht".to_string()),
-    };
+    #[test]
+    fn test_dto_into_struct() {
+        let person = PersonDto {
+            firstname: "Dessalines".to_string(),
+            lastname: "Jean Jacques".to_string(),
+            email: Some("dessalines@mail.ht".to_string()),
+        };
 
-    let user_from_person: User = person.into();
+        let user_from_person: User = person.into();
 
-    assert_eq!("Dessalines", user_from_person.firstname);
-    assert_eq!("Jean Jacques", user_from_person.lastname);
-    assert_eq!("dessalines@mail.ht", user_from_person.email);
+        assert_eq!("Dessalines", user_from_person.firstname);
+        assert_eq!("Jean Jacques", user_from_person.lastname);
+        assert_eq!("dessalines@mail.ht", user_from_person.email);
 
-    //assert all the remaining fields are all initialized with default value from User::default
-    assert_eq!(User::default().username, user_from_person.username);
-    assert_eq!(User::default().password, user_from_person.password);
-    assert_eq!(User::default().middle_name, user_from_person.middle_name);
-    assert_eq!(User::default().age, user_from_person.age);
-  }
+        //assert all the remaining fields are all initialized with default value from User::default
+        assert_eq!(User::default().username, user_from_person.username);
+        assert_eq!(User::default().password, user_from_person.password);
+        assert_eq!(User::default().middle_name, user_from_person.middle_name);
+        assert_eq!(User::default().age, user_from_person.age);
+    }
 
-  #[test]
-  fn test_dto_with_builder() {
-    let mut login_dto_builder = LoginDtoBuilder::default();
-    let login_dto = login_dto_builder
-      .login("capois-lamort".into())
-      .password("hello123".into())
-      .build()
-      .expect("Failed to build login dto");
-    println!("LoginDto built with a builder: {:?}", login_dto);
-  }
+    #[test]
+    fn test_dto_with_builder() {
+        let mut login_dto_builder = LoginDtoBuilder::default();
+        let login_dto = login_dto_builder
+            .login("capois-lamort".into())
+            .password("hello123".into())
+            .build()
+            .expect("Failed to build login dto");
+        println!("LoginDto built with a builder: {:?}", login_dto);
+    }
 
-  #[test]
-  fn test_custom_dto_expression() {
-    let user = User {
-      firstname: "Dessalines".into(),
-      lastname: "Jean Jacques".into(),
-      ..User::default()
-    };
+    #[test]
+    fn test_custom_dto_expression() {
+        let user = User {
+            firstname: "Dessalines".into(),
+            lastname: "Jean Jacques".into(),
+            ..User::default()
+        };
 
-    let custom_dto: CustomDto = user.clone().into();
+        let custom_dto: CustomDto = user.clone().into();
 
-    assert_eq!(
-      custom_dto.name,
-      format!("{} {}", user.firstname, user.lastname)
-    );
-  }
+        assert_eq!(
+            custom_dto.name,
+            format!("{} {}", user.firstname, user.lastname)
+        );
+    }
 
-  #[test]
-  fn test_custom_dto_with_struct_attributes() {
-    let user = CustomDtoWithAttribute {
-      email: Some("Dessalines@gmail.com".to_string()),
-      name: "Jean Jacques".into(),
-      ..CustomDtoWithAttribute::default()
-    };
-    let custom_dto: CustomDtoWithAttribute = user.clone().into();
-    assert_eq!(custom_dto.email, user.email);
+    #[test]
+    fn test_custom_dto_with_struct_attributes() {
+        let user = CustomDtoWithAttribute {
+            email: Some("Dessalines@gmail.com".to_string()),
+            name: "Jean Jacques".into(),
+            ..CustomDtoWithAttribute::default()
+        };
+        let custom_dto: CustomDtoWithAttribute = user.clone().into();
+        assert_eq!(custom_dto.email, user.email);
 
-    // check json serialization
-    let json_string = serde_json::to_string(&custom_dto).unwrap();
-    assert_eq!(
-      json_string,
-      r#"{"EMAIL":"Dessalines@gmail.com","renamed_name":"Jean Jacques"}"#
-    );
-  }
+        // check json serialization
+        let json_string = serde_json::to_string(&custom_dto).unwrap();
+        assert_eq!(
+            json_string,
+            r#"{"EMAIL":"Dessalines@gmail.com","renamed_name":"Jean Jacques"}"#
+        );
+    }
 }

--- a/tests/test_dto_creation.rs
+++ b/tests/test_dto_creation.rs
@@ -22,12 +22,12 @@ mod test_dto_creation {
     #[mapper(
     dto="CustomDtoWithAttribute" ,
     no_builder=true ,
-    map=[ ("email",false) ],
+    map=[ ("email", false, ["#[serde(rename = \"email_address\")]"] ) ],
     derive=(Debug, Clone, Serialize, Deserialize),
     new_fields=[(
         "name: String",
         "concat_str( self.firstname.as_str(), self.lastname.as_str() )",
-        ["#[serde(rename = \"renamed_name\")]"],
+        ["#[serde(rename = \"full_name\")]"],
     )],
     macro_attr=["serde(rename_all = \"UPPERCASE\")"]
   )]
@@ -161,7 +161,7 @@ mod test_dto_creation {
         let json_string = serde_json::to_string(&custom_dto).unwrap();
         assert_eq!(
             json_string,
-            r#"{"EMAIL":"Dessalines@gmail.com","renamed_name":"Jean Jacques"}"#
+            r#"{"email_address":"Dessalines@gmail.com","full_name":"Jean Jacques"}"#
         );
     }
 }


### PR DESCRIPTION
This Pull request is the follow-up of this one with the pending required changes:
https://github.com/douggynix/dto_mapper/pull/11

The changes will add macro attributes as well for mapping struct fields:
```rust
 #[derive(DtoMapper, Debug, Default, Clone)]
#[mapper(
    dto="CustomDtoWithAttribute" ,
    no_builder=true ,
    map=[ ("email", false, ["#[serde(rename = \"email_address\")]"] ) ],
    derive=(Debug, Clone, Serialize, Deserialize),
    new_fields=[
        (
            "name: String",
            "concat_str( self.firstname.as_str(), self.lastname.as_str() )",
            ["#[serde(rename = \"full_name\")]"],
        ),
        (
          "hidden_password: String",
         r#""*".repeat( self.password.len() )"#
        ),
    ],
    macro_attr=["serde(rename_all = \"UPPERCASE\")"]
)]
    struct User {
        username: String,
        password: String,
        email: String,
        firstname: String,
        middle_name: Option<String>,
        lastname: String,
        age: u8,
    }
```

The macro definition above will generate this new struct with the attributes added in the mapping field.
Run this command to view the result:
```shell
cargo install cargo-expand
cargo expand --test dto_example
```

```rust
#[serde(rename_all = "UPPERCASE")]
pub struct CustomDtoWithAttribute {
    #[serde(rename = "email_address")]
    pub email: Option<String>,
    #[serde(rename = "full_name")]
    pub name: String,
    pub hidden_password: String,
}
```